### PR TITLE
Use published ostree-ext 0.10

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.63.0"
 [dependencies]
 anyhow = "1.0"
 camino = "1.0.4"
-ostree-ext = { git = "https://github.com/ostreedev/ostree-rs-ext" }
+ostree-ext = "0.10.0"
 clap = { version= "3.2", features = ["derive"] }
 clap_mangen = { version = "0.1", optional = true }
 cap-std-ext = "1.0.1"


### PR DESCRIPTION
I just pushed this out, should fix the `cargo deny` failures.