### PR TITLE
Add initial CI infrastructure designed for Prow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.cosa
+target

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ example
 
 /target
 Cargo.lock
+bootc.tar.zst

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+prefix ?= /usr
+
+all:
+	cargo build --release
+    
+install:
+	install -D -t $(DESTDIR)$(prefix)/bin target/release/bootc
+
+bin-archive: all
+	$(MAKE) install DESTDIR=tmp-install && tar --zstd -C tmp-install -cf bootc.tar.zst . && rm tmp-install -rf
+
+install-kola-tests:
+	install -D -t $(DESTDIR)$(prefix)/lib/coreos-assembler/tests/kola/bootc tests/kolainst/basic

--- a/ci/Dockerfile.ci
+++ b/ci/Dockerfile.ci
@@ -1,0 +1,10 @@
+# This really just depends on `cosa run`, which we could
+# in theory split out separately at some point later.
+FROM quay.io/coreos-assembler/coreos-assembler:latest
+WORKDIR /srv
+USER root
+# Grab all of our ci scripts
+COPY /src/ci/ /ci/
+RUN ln -sr /ci/run-kola.sh /usr/bin/bootc-run-kola
+USER builder
+CMD ["/usr/bin/bootc-run-kola"]

--- a/ci/Dockerfile.fcos
+++ b/ci/Dockerfile.fcos
@@ -1,0 +1,10 @@
+# This Dockerfile generates a container image that installs bootc into
+# a Fedora CoreOS image.
+FROM quay.io/coreos-assembler/fcos-buildroot:testing-devel as builder
+WORKDIR /src
+COPY . .
+RUN make bin-archive
+
+FROM quay.io/fedora/fedora-coreos:testing-devel
+COPY --from=builder /src/bootc.tar.zst /tmp
+RUN tar -xvf /tmp/bootc.tar.zst && ostree container commit 

--- a/ci/run-kola.sh
+++ b/ci/run-kola.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# We require the an image containing bootc-under-test to have been injected
+# by an external system, e.g. Prow 
+# https://docs.ci.openshift.org/docs/architecture/ci-operator/#referring-to-images-in-tests
+if test -z "${TARGET_IMAGE:-}"; then
+    echo "fatal: Must set TARGET_IMAGE" 1>&2; exit 1
+fi
+echo "Test base image: ${TARGET_IMAGE}"
+
+tmpdir="$(mktemp -d -p /var/tmp)"
+cd "${tmpdir}"
+if test -z "${BASE_QEMU_IMAGE:-}"; then
+    coreos-installer download -p qemu -f qcow2.xz --decompress
+    BASE_QEMU_IMAGE="$(echo *.qcow2)"
+fi
+kola run --oscontainer ostree-unverified-registry:${TARGET_IMAGE} --qemu-image "./${BASE_QEMU_IMAGE}" ext.bootc.'*'
+
+echo "ok kola bootc"

--- a/tests/kolainst/basic
+++ b/tests/kolainst/basic
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Verify basic bootc functionality.
+## kola:
+##   timeoutMin: 30
+##   tags: "needs-internet"
+#
+# Copyright (C) 2022 Red Hat, Inc.
+
+set -xeuo pipefail
+
+cd $(mktemp -d)
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "")
+    bootc status --json > status.json
+    image=$(jq -r '.[0].image.image' < status.json)
+    echo "booted into $image"
+
+    # TODO more tests here
+
+    echo "ok status test"
+    ;;
+  *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
+esac


### PR DESCRIPTION
This test will

- build a container image derived from FCOS, injecting bootc-under-test into it
- Schedule a separate container derived from coreos-assembler which has a reference to that container injected via https://docs.ci.openshift.org/docs/architecture/ci-operator/#referring-to-images-in-tests
- Run the stable FCOS base image via kola (qemu), injecting the target oscontainer
- Execute a basic test that just verifies `status --json` today

However, in the future we can change the build system to generate multiple container images, and test upgrades, rollbacks, etc.