### PR TITLE
Cleanly display/error if origin is rpm-ostree owned

### DIFF
--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -24,6 +24,19 @@ pub(crate) fn get_image_origin(
     Ok((origin, imgref))
 }
 
+/// Try to look for keys injected by e.g. rpm-ostree requesting machine-local
+/// changes; if any are present, return `true`.
+pub(crate) fn origin_has_rpmostree_stuff(kf: &glib::KeyFile) -> bool {
+    // These are groups set in https://github.com/coreos/rpm-ostree/blob/27f72dce4f9b5c176ad030911c12354e2498c07d/rust/src/origin.rs#L23
+    // TODO: Add some notion of "owner" into origin files
+    for group in ["rpmostree", "packages", "overrides", "modules"] {
+        if kf.has_group(group) {
+            return true;
+        }
+    }
+    false
+}
+
 /// Print the deployment we staged.
 pub(crate) fn print_staged(deployment: &ostree::Deployment) -> Result<()> {
     let (_origin, imgref) = get_image_origin(deployment)?;


### PR DESCRIPTION
If one does any machine-local layering/overrides via rpm-ostree, we really should error out if one does `bootc upgrade`; otherwise we'll just lose their changes.

This is a bit of an ugly hack; what would be more elegant is to add something like a clear `owner` flag into origin files, and have rpm-ostree flip that on if it needs to take over.

But for now, let's do this to avoid more confusion.