### PR TITLE
switch: Fix changing from an ostree remote

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -331,7 +331,9 @@ async fn switch(opts: SwitchOpts) -> Result<()> {
     if !opts.retain {
         // By default, we prune the previous ostree ref or container image
         if let Some(ostree_ref) = booted_refspec {
-            repo.set_ref_immediate(None, &ostree_ref, None, cancellable)?;
+            let (remote, ostree_ref) =
+                ostree::parse_refspec(&ostree_ref).context("Failed to parse ostree ref")?;
+            repo.set_ref_immediate(remote.as_deref(), &ostree_ref, None, cancellable)?;
             origin.remove_key("origin", "refspec")?;
         } else if let Some(booted_image) = booted_image.as_ref() {
             ostree_container::store::remove_image(repo, &booted_image.imgref)?;


### PR DESCRIPTION
When we added logic to prune previous containers, we broke switching from an ostree remote + ref.  We need to parse the ref to handle the remote.

Closes: https://github.com/containers/bootc/issues/19