### PR TITLE
Enable `cargo vendor-filterer`

### DIFF
--- a/.github/workflows/autovendor.yml
+++ b/.github/workflows/autovendor.yml
@@ -1,0 +1,24 @@
+# Automatically generate a vendor.tar.zstd on pushes to git main.
+name: Auto-vendor artifact
+
+permissions:
+  actions: read
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  vendor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install vendor tool
+        run: cargo install cargo-vendor-filterer
+      - name: Run
+        run: mkdir -p target && cd cli && cargo vendor-filterer --format=tar.zstd --prefix=vendor/ ../target/vendor.tar.zst
+      - uses: actions/upload-artifact@v3
+        with:
+          name: vendor.tar.zst
+          path: target/vendor.tar.zst

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,6 +8,13 @@ readme = "README.md"
 publish = false
 rust-version = "1.63.0"
 
+# See https://github.com/coreos/cargo-vendor-filterer
+[package.metadata.vendor-filter]
+# This list of platforms is not intended to be exclusive, feel free
+# to extend it.  But missing a platfom will only matter for the case where
+# a dependent crate is *only* built on that platform.
+platforms = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "powerpc64le-unknown-linux-gnu", "s390x-unknown-linux-gnu", "riscv64gc-unknown-linux-gnu"]
+
 [dependencies]
 anyhow = "1.0"
 bootc-lib = { path = "../lib" }


### PR DESCRIPTION
Add configuration and a GH action post-push which automatically generates a vendor tar.