### PR TITLE
Update to ostree-ext 0.10.1, add SELinux verification

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.63.0"
 [dependencies]
 anyhow = "1.0"
 camino = "1.0.4"
-ostree-ext = "0.10.0"
+ostree-ext = "0.10.1"
 clap = { version= "3.2", features = ["derive"] }
 clap_mangen = { version = "0.1", optional = true }
 cap-std-ext = "1.0.1"

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -262,9 +262,16 @@ async fn stage(
     Ok(())
 }
 
+/// A few process changes that need to be made for writing.
+async fn prepare_for_write() -> Result<()> {
+    ensure_self_unshared_mount_namespace().await?;
+    ostree_ext::selinux::verify_install_domain()?;
+    Ok(())
+}
+
 /// Implementation of the `bootc upgrade` CLI command.
 async fn upgrade(opts: UpgradeOpts) -> Result<()> {
-    ensure_self_unshared_mount_namespace().await?;
+    prepare_for_write().await?;
     let sysroot = &get_locked_sysroot().await?;
     let repo = &sysroot.repo().unwrap();
     let booted_deployment = &sysroot.require_booted_deployment()?;
@@ -303,7 +310,8 @@ async fn upgrade(opts: UpgradeOpts) -> Result<()> {
 
 /// Implementation of the `bootc switch` CLI command.
 async fn switch(opts: SwitchOpts) -> Result<()> {
-    ensure_self_unshared_mount_namespace().await?;
+    prepare_for_write().await?;
+
     let cancellable = gio::Cancellable::NONE;
     let sysroot = get_locked_sysroot().await?;
     let booted_deployment = &sysroot.require_booted_deployment()?;


### PR DESCRIPTION
This uses the new ostree API to verify we're in a compatible SELinux domain.  Otherwise, it's a really evil trap because things *seem* to work fine but will just explode in the case when trying to do a major policy update.