### PR TITLE
ci/run-kola: Support pull secret for running in Prow

### DIFF
--- a/ci/run-kola.sh
+++ b/ci/run-kola.sh
@@ -9,12 +9,31 @@ if test -z "${TARGET_IMAGE:-}"; then
 fi
 echo "Test base image: ${TARGET_IMAGE}"
 
+
 tmpdir="$(mktemp -d -p /var/tmp)"
 cd "${tmpdir}"
+
+# Detect Prow; if we find it, assume the image requires a pull secret
+kola_args=()
+if test -n "${JOB_NAME_HASH:-}"; then
+    oc registry login --to auth.json
+    cat > pull-secret.bu << 'EOF'
+variant: fcos
+version: 1.1.0
+storage:
+  files:
+    - path: /etc/ostree/auth.json
+      contents:
+        local: auth.json
+EOF
+    butane -d . < pull-secret.bu > pull-secret.ign
+    kola_args+=("--append-ignition" "pull-secret.ign")
+fi
+
 if test -z "${BASE_QEMU_IMAGE:-}"; then
     coreos-installer download -p qemu -f qcow2.xz --decompress
     BASE_QEMU_IMAGE="$(echo *.qcow2)"
 fi
-kola run --oscontainer ostree-unverified-registry:${TARGET_IMAGE} --qemu-image "./${BASE_QEMU_IMAGE}" ext.bootc.'*'
+kola run --oscontainer ostree-unverified-registry:${TARGET_IMAGE} --qemu-image "./${BASE_QEMU_IMAGE}" "${kola_args[@]}" ext.bootc.'*'
 
 echo "ok kola bootc"


### PR DESCRIPTION
This is needed to support fetching the image from the registry.