### PR TITLE
Add an `internal-tests run-privileged-integration`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           key: "build"
       - name: Build
-        run: cargo build --release
+        run: cargo build --release --features internal-testing-api
       - name: Upload binary
         uses: actions/upload-artifact@v2
         with:
@@ -110,21 +110,22 @@ jobs:
         run: cargo fmt -- --check -l
       - name: cargo clippy (warnings)
         run: cargo clippy -- -D warnings
-  # privtest:
-  #   name: "Privileged testing"
-  #   needs: build
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: quay.io/fedora/fedora-coreos:testing-devel
-  #     options: "--privileged --pid=host -v /run/systemd:/run/systemd -v /:/run/host"
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v3
-  #     - name: Download
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: bootc
-  #     - name: Install
-  #       run: install bootc /usr/bin && rm -v bootc
-  #     - name: Integration tests
-  #       run: ./ci/priv-integration.sh
+  privtest:
+    name: "Privileged testing"
+    needs: build
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/fedora/fedora-coreos:testing-devel
+      options: "--privileged --pid=host -v /run/systemd:/run/systemd -v /:/run/host"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Download
+        uses: actions/download-artifact@v2
+        with:
+          name: bootc
+      - name: Install
+        run: install bootc /usr/bin && rm -v bootc
+      - name: Integration tests
+        run: bootc internal-tests run-privileged-integration
+

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -21,7 +21,10 @@ serde_json = "1.0.64"
 tokio = { features = ["io-std", "time", "process", "rt", "net"], version = ">= 1.13.0" }
 tokio-util = { features = ["io-util"], version = "0.7" }
 tracing = "0.1"
+tempfile = "3.3.0"
+xshell = { version = "0.2", optional = true }
 
 [features]
+default = []
 docgen = ["clap_mangen"]
-
+internal-testing-api = ["xshell"]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -14,6 +14,8 @@
 #![deny(clippy::todo)]
 
 pub mod cli;
+#[cfg(feature = "internal-testing-api")]
+mod privtests;
 mod status;
 mod utils;
 

--- a/lib/src/privtests.rs
+++ b/lib/src/privtests.rs
@@ -1,0 +1,72 @@
+use std::process::Command;
+
+use anyhow::Result;
+use camino::{Utf8Path, Utf8PathBuf};
+use cap_std_ext::rustix;
+use rustix::fd::AsFd;
+use xshell::{cmd, Shell};
+
+use super::cli::TestingOpts;
+
+const IMGSIZE: u64 = 20 * 1024 * 1024 * 1024;
+
+struct LoopbackDevice {
+    #[allow(dead_code)]
+    tmpf: tempfile::NamedTempFile,
+    dev: Utf8PathBuf,
+}
+
+impl LoopbackDevice {
+    fn new_temp(sh: &xshell::Shell) -> Result<Self> {
+        let mut tmpd = tempfile::NamedTempFile::new_in("/var/tmp")?;
+        rustix::fs::ftruncate(tmpd.as_file_mut().as_fd(), IMGSIZE)?;
+        let diskpath = tmpd.path();
+        let path = cmd!(sh, "losetup --find --show {diskpath}").read()?;
+        Ok(Self {
+            tmpf: tmpd,
+            dev: path.into(),
+        })
+    }
+}
+
+impl Drop for LoopbackDevice {
+    fn drop(&mut self) {
+        let _ = Command::new("losetup")
+            .args(["-d", self.dev.as_str()])
+            .status();
+    }
+}
+
+fn init_ostree(sh: &Shell, rootfs: &Utf8Path) -> Result<()> {
+    cmd!(sh, "ostree admin init-fs --modern {rootfs}").run()?;
+    Ok(())
+}
+
+pub(crate) fn impl_run() -> Result<()> {
+    let sh = Shell::new()?;
+
+    let loopdev = LoopbackDevice::new_temp(&sh)?;
+    let devpath = &loopdev.dev;
+    println!("Using {devpath:?}");
+
+    let td = tempfile::tempdir()?;
+    let td = td.path();
+    let td: &Utf8Path = td.try_into()?;
+
+    cmd!(sh, "mkfs.xfs {devpath}").run()?;
+
+    cmd!(sh, "mount {devpath} {td}").run()?;
+
+    init_ostree(&sh, td)?;
+
+    let _g = sh.push_env("OSTREE_SYSROOT", td);
+    cmd!(sh, "bootc status").run()?;
+
+    Ok(())
+}
+
+pub(crate) async fn run(opts: &TestingOpts) -> Result<()> {
+    match opts {
+        TestingOpts::RunPrivilegedIntegration {} => tokio::task::spawn_blocking(impl_run).await?,
+    }
+}


### PR DESCRIPTION
status: Don't error out if not booted

For now, just print out nothing.  This helps a future integration
testing scenario.

---

Add an `internal-tests run-privileged-integration`

Add a feature to enable internal tests.  I originally started
by matching
https://github.com/ostreedev/ostree-rs-ext/commit/6543c855580da3a3f2a85bc8b4a294b4c92c2829
but since here the binary is really end user facing and not just
a demo, we shouldn't enable the feature by default.

If in the future we split off the tiny CLI bit out of the workspace,
then we could auto-enable but that seems not worth it.

---

