### PR TITLE
Small prep patches for `install`

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -15,6 +15,7 @@ ostree-ext = "0.10.1"
 clap = { version= "3.2", features = ["derive"] }
 clap_mangen = { version = "0.1", optional = true }
 cap-std-ext = "1.0.1"
+fn-error-context = "0.2.0"
 indicatif = "0.17.0"
 serde = { features = ["derive"], version = "1.0.125" }
 serde_json = "1.0.64"

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -5,6 +5,7 @@
 use anyhow::{Context, Result};
 use camino::Utf8PathBuf;
 use clap::Parser;
+use fn_error_context::context;
 use ostree::{gio, glib};
 use ostree_container::store::LayeredImageState;
 use ostree_container::store::PrepareResult;
@@ -133,6 +134,7 @@ async fn ensure_self_unshared_mount_namespace() -> Result<()> {
 
 /// Acquire a locked sysroot.
 /// TODO drain this and the above into SysrootLock
+#[context("Acquiring sysroot")]
 pub(crate) async fn get_locked_sysroot() -> Result<ostree_ext::sysroot::SysrootLock> {
     let sysroot = ostree::Sysroot::new_default();
     sysroot.set_mount_namespace_in_use();
@@ -142,6 +144,7 @@ pub(crate) async fn get_locked_sysroot() -> Result<ostree_ext::sysroot::SysrootL
 }
 
 /// Wrapper for pulling a container image, wiring up status output.
+#[context("Pulling")]
 async fn pull(
     repo: &ostree::Repo,
     imgref: &OstreeImageReference,
@@ -181,6 +184,7 @@ async fn pull(
 }
 
 /// Stage (queue deployment of) a fetched container image.
+#[context("Staging")]
 async fn stage(
     sysroot: &SysrootLock,
     stateroot: &str,
@@ -204,6 +208,7 @@ async fn stage(
 }
 
 /// A few process changes that need to be made for writing.
+#[context("Preparing for write")]
 async fn prepare_for_write() -> Result<()> {
     ensure_self_unshared_mount_namespace().await?;
     ostree_ext::selinux::verify_install_domain()?;
@@ -211,6 +216,7 @@ async fn prepare_for_write() -> Result<()> {
 }
 
 /// Implementation of the `bootc upgrade` CLI command.
+#[context("Upgrading")]
 async fn upgrade(opts: UpgradeOpts) -> Result<()> {
     prepare_for_write().await?;
     let sysroot = &get_locked_sysroot().await?;
@@ -250,6 +256,7 @@ async fn upgrade(opts: UpgradeOpts) -> Result<()> {
 }
 
 /// Implementation of the `bootc switch` CLI command.
+#[context("Switching")]
 async fn switch(opts: SwitchOpts) -> Result<()> {
     prepare_for_write().await?;
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -16,6 +16,7 @@
 pub mod cli;
 #[cfg(feature = "internal-testing-api")]
 mod privtests;
+mod reexec;
 mod status;
 mod utils;
 

--- a/lib/src/reexec.rs
+++ b/lib/src/reexec.rs
@@ -1,0 +1,19 @@
+use std::os::unix::process::CommandExt;
+
+use anyhow::Result;
+use fn_error_context::context;
+
+/// Re-execute the current process if the provided environment variable is not set.
+#[context("Reexec self")]
+pub(crate) fn reexec_with_guardenv(k: &str) -> Result<()> {
+    if std::env::var_os(k).is_some() {
+        return Ok(());
+    }
+    let self_exe = std::fs::read_link("/proc/self/exe")?;
+    let mut cmd = std::process::Command::new("unshare");
+    cmd.env(k, "1");
+    cmd.args(["-m", "--"])
+        .arg(self_exe)
+        .args(std::env::args_os().skip(1));
+    Err(cmd.exec().into())
+}

--- a/lib/src/status.rs
+++ b/lib/src/status.rs
@@ -120,7 +120,7 @@ pub(crate) async fn status(opts: super::cli::StatusOpts) -> Result<()> {
 
     // We're not writing to JSON; iterate over and print.
     for (deployment, info) in deployments {
-        let booted_display = info.booted.then(|| "* ").unwrap_or(" ");
+        let booted_display = if info.booted { "* " } else { " " };
         let image: Option<OstreeImageReference> = info.image.as_ref().map(|i| i.clone().into());
 
         let commit = info.checksum;


### PR DESCRIPTION
status: Use `if` instead of `.then(||)`

It's equally clear and avoids clippy lint conflicts between different
Rust versions.

---

cli: Add some error prefixing

On general principle.

---

Add a `reexec` helper

Prep for the `install` path where we will use this in
more ways.

---

