### PR TITLE
reexec: Generalize a bit

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -128,7 +128,7 @@ pub(crate) async fn ensure_self_unshared_mount_namespace() -> Result<()> {
             anyhow::bail!("Failed to unshare mount namespace");
         }
     }
-    crate::reexec::reexec_with_guardenv(recurse_env)
+    crate::reexec::reexec_with_guardenv(recurse_env, &["unshare", "-m", "--"])
 }
 
 /// Acquire a locked sysroot.

--- a/lib/src/reexec.rs
+++ b/lib/src/reexec.rs
@@ -1,19 +1,26 @@
 use std::os::unix::process::CommandExt;
+use std::process::Command;
 
 use anyhow::Result;
 use fn_error_context::context;
 
 /// Re-execute the current process if the provided environment variable is not set.
 #[context("Reexec self")]
-pub(crate) fn reexec_with_guardenv(k: &str) -> Result<()> {
+pub(crate) fn reexec_with_guardenv(k: &str, prefix_args: &[&str]) -> Result<()> {
     if std::env::var_os(k).is_some() {
         return Ok(());
     }
     let self_exe = std::fs::read_link("/proc/self/exe")?;
-    let mut cmd = std::process::Command::new("unshare");
+    let mut prefix_args = prefix_args.iter();
+    let mut cmd = if let Some(p) = prefix_args.next() {
+        let mut c = Command::new(p);
+        c.args(prefix_args);
+        c.arg(self_exe);
+        c
+    } else {
+        Command::new(self_exe)
+    };
     cmd.env(k, "1");
-    cmd.args(["-m", "--"])
-        .arg(self_exe)
-        .args(std::env::args_os().skip(1));
+    cmd.args(std::env::args_os().skip(1));
     Err(cmd.exec().into())
 }


### PR DESCRIPTION
The rexec logic was hardcoded to run `unshare -m`; move that bit into the caller so the core re-exec does literally just that.

Prep for other re-exec callers in the install code.