### PR TITLE
Install fixes

### DIFF
--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -642,10 +642,12 @@ pub(crate) async fn install(opts: InstallOpts) -> Result<()> {
 
     // Let's ensure we have a tmpfs on /tmp, because we need that to write the SELinux label
     // (it won't work on the default overlayfs)
-    Task::new("Creating tmpfs on /tmp", "mount")
-        .quiet()
-        .args(["-t", "tmpfs", "tmpfs", "/tmp"])
-        .run()?;
+    if nix::sys::statfs::statfs("/tmp")?.filesystem_type() != nix::sys::statfs::TMPFS_MAGIC {
+        Task::new("Creating tmpfs on /tmp", "mount")
+            .quiet()
+            .args(["-t", "tmpfs", "tmpfs", "/tmp"])
+            .run()?;
+    }
 
     // Now, deal with SELinux state.
     let srcdata = gather_source_data()?;

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -657,6 +657,13 @@ pub(crate) async fn install(opts: InstallOpts) -> Result<()> {
         let host_selinux = crate::lsm::selinux_enabled()?;
         tracing::debug!("Target has SELinux, host={host_selinux}");
         if host_selinux {
+            // /sys/fs/selinuxfs is not normally mounted, so we do that now.
+            // Because SELinux enablement status is cached process-wide and was very likely
+            // already queried by something else (e.g. glib's constructor), we would also need
+            // to re-exec.  But, selinux_ensure_install does that unconditionally right now too,
+            // so let's just fall through to that.
+            crate::lsm::container_setup_selinux()?;
+            // This will re-execute the current process (once).
             crate::lsm::selinux_ensure_install()?;
         } else if opts.disable_selinux {
             override_disable_selinux = true;
@@ -668,13 +675,6 @@ pub(crate) async fn install(opts: InstallOpts) -> Result<()> {
         }
     } else {
         tracing::debug!("Target does not enable SELinux");
-    }
-
-    // Because SELinux enablement status is cached process-wide and was very likely
-    // already queried by something else (e.g. glib's constructor), we need to mount
-    // selinuxfs now if needed, then re-exec *again*.
-    if srcdata.selinux && !override_disable_selinux {
-        crate::lsm::container_setup_selinux()?;
     }
 
     // Create our global (read-only) state which gets wrapped in an Arc

--- a/lib/src/lsm.rs
+++ b/lib/src/lsm.rs
@@ -60,14 +60,14 @@ pub(crate) fn container_setup_selinux() -> Result<()> {
     let path = Utf8Path::new(SELINUXFS);
     if !path.join("enforce").exists() {
         if !path.exists() {
+            tracing::debug!("Creating {path}");
             std::fs::create_dir(path)?;
         }
         Task::new("Mounting selinuxfs", "mount")
             .args(["selinuxfs", "-t", "selinuxfs", path.as_str()])
             .run()?;
     }
-
-    selinux_ensure_install()
+    Ok(())
 }
 
 fn selinux_label_for_path(target: &str) -> Result<String> {

--- a/lib/src/lsm.rs
+++ b/lib/src/lsm.rs
@@ -29,6 +29,8 @@ pub(crate) fn selinux_ensure_install() -> Result<()> {
         if p.exists() {
             tracing::debug!("Removing temporary file");
             std::fs::remove_file(p).context("Removing {p:?}")?;
+        } else {
+            tracing::debug!("Assuming we now have a privileged (e.g. install_t) label");
         }
         return Ok(());
     }
@@ -50,6 +52,7 @@ pub(crate) fn selinux_ensure_install() -> Result<()> {
     let mut cmd = Command::new(&tmpf);
     cmd.env(guardenv, tmpf);
     cmd.args(std::env::args_os().skip(1));
+    tracing::debug!("Re-executing");
     Err(anyhow::Error::msg(cmd.exec()).context("execve"))
 }
 

--- a/lib/src/reexec.rs
+++ b/lib/src/reexec.rs
@@ -8,6 +8,7 @@ use fn_error_context::context;
 #[context("Reexec self")]
 pub(crate) fn reexec_with_guardenv(k: &str, prefix_args: &[&str]) -> Result<()> {
     if std::env::var_os(k).is_some() {
+        tracing::trace!("Skipping re-exec due to env var {k}");
         return Ok(());
     }
     let self_exe = std::fs::read_link("/proc/self/exe")?;
@@ -22,5 +23,6 @@ pub(crate) fn reexec_with_guardenv(k: &str, prefix_args: &[&str]) -> Result<()> 
     };
     cmd.env(k, "1");
     cmd.args(std::env::args_os().skip(1));
+    tracing::debug!("Re-executing current process for {k}");
     Err(cmd.exec().into())
 }


### PR DESCRIPTION
install: Make `/tmp` mount idempotent

Just so that the output of `findmnt` looks cleaner.

---

install: Always mount selinuxfs *before* install_t re-execution

My changes to ensure `install_t` actually re-broke the labeling
on `/etc`, because we were mounting selinuxfs *after* the
re-exec.

Reorder and clean up things so that we always do the mount
before the re-exec for install_t.

---

Add more debug/trace logs

This helped me debug a selinux regression.

---

