### PR TITLE
Add a default-enabled `install` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
           key: "tests"
       - name: Build
         run: cargo test --no-run
+      - name: Build lib without default features
+        run: cd lib && cargo check --no-default-features
       - name: Individual checks
         run: (cd cli && cargo check) && (cd lib && cargo check)
       - name: Run tests

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -34,6 +34,10 @@ xshell = { version = "0.2", optional = true }
 uuid = { version = "1.2.2", features = ["v4"] }
 
 [features]
-default = []
+default = ["install"]
+# This feature enables `bootc install`.  Disable if you always want to use an external installer.
+install = []
+# Implementation detail of man page generation.
 docgen = ["clap_mangen"]
+# This feature should only be enabled in CI environments.
 internal-testing-api = ["xshell"]

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -97,6 +97,7 @@ pub(crate) enum Opt {
     /// Display status
     Status(StatusOpts),
     /// Install to the target block device
+    #[cfg(feature = "install")]
     Install(crate::install::InstallOpts),
     /// Internal integration testing helpers.
     #[clap(hide(true), subcommand)]
@@ -333,6 +334,7 @@ where
     match opt {
         Opt::Upgrade(opts) => upgrade(opts).await,
         Opt::Switch(opts) => switch(opts).await,
+        #[cfg(feature = "install")]
         Opt::Install(opts) => crate::install::install(opts).await,
         Opt::Status(opts) => super::status::status(opts).await,
         #[cfg(feature = "internal-testing-api")]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -13,20 +13,29 @@
 #![deny(clippy::dbg_macro)]
 #![deny(clippy::todo)]
 
-mod blockdev;
-mod bootloader;
 pub mod cli;
-mod containerenv;
-pub(crate) mod ignition;
-mod install;
 mod lsm;
-mod podman;
-#[cfg(feature = "internal-testing-api")]
-mod privtests;
 mod reexec;
 mod status;
-mod task;
 mod utils;
+
+#[cfg(feature = "internal-testing-api")]
+mod privtests;
+
+#[cfg(feature = "install")]
+mod blockdev;
+#[cfg(feature = "install")]
+mod bootloader;
+#[cfg(feature = "install")]
+mod containerenv;
+#[cfg(feature = "install")]
+pub(crate) mod ignition;
+#[cfg(feature = "install")]
+mod install;
+#[cfg(feature = "install")]
+mod podman;
+#[cfg(feature = "install")]
+mod task;
 
 #[cfg(feature = "docgen")]
 mod docgen;

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -49,6 +49,7 @@ where
 }
 
 /// Run a command in the host mount namespace
+#[allow(dead_code)]
 pub(crate) fn run_in_host_mountns(cmd: &str) -> Command {
     let mut c = Command::new("nsenter");
     c.args(["-m", "-t", "1", "--", cmd]);
@@ -57,6 +58,7 @@ pub(crate) fn run_in_host_mountns(cmd: &str) -> Command {
 
 /// Given a possibly tagged image like quay.io/foo/bar:latest and a digest 0ab32..., return
 /// the digested form quay.io/foo/bar@sha256:0ab32...
+#[allow(dead_code)]
 pub(crate) fn digested_pullspec(image: &str, digest: &str) -> String {
     let image = image.rsplit_once(':').map(|v| v.0).unwrap_or(image);
     format!("{image}@{digest}")


### PR DESCRIPTION
The install code greatly increases the scope of this project.  Not every OS/distribution will want it on by default; some may always want to use their own install code.

Having a feature for this shows that while we're opinionated, we're also flexible.

Signed-off-by: Colin Walters <walters@verbum.org>