### PR TITLE
Prep patches for `install-to-filesystem`

### DIFF
--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -611,7 +611,8 @@ fn install_create_rootfs(state: &State) -> Result<RootSetup> {
     let root_uuid = mkfs(rootdev, opts.filesystem, Some("root"), [])?;
     let rootarg = format!("root=UUID={root_uuid}");
     let bootarg = format!("boot=UUID={boot_uuid}");
-    let kargs = vec![rootarg, RW_KARG.to_string(), bootarg];
+    let mut kargs = opts.config_opts.karg.clone().unwrap_or_default();
+    kargs.extend([rootarg, RW_KARG.to_string(), bootarg]);
 
     mount(rootdev, &rootfs)?;
     lsm_label(&rootfs, "/".into(), false)?;

--- a/tests/kolainst/install
+++ b/tests/kolainst/install
@@ -12,15 +12,19 @@ set -xeuo pipefail
 
 # See https://github.com/cgwalters/bootc-base-images
 IMAGE=quay.io/cgwalters/fedora-oscore:latest
+# TODO: better detect this, e.g. look for an empty device
+DEV=/dev/vda
 
 # Always work out of a temporary directory
 cd $(mktemp -d)
 
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "")
-    podman run --rm -ti --privileged --pid=host --net=none -v /usr/bin/bootc:/usr/bin/bootc ${IMAGE} bootc install /dev/vda
+    podman run --rm -ti --privileged --pid=host --net=none -v /usr/bin/bootc:/usr/bin/bootc ${IMAGE} bootc install --karg=foo=bar ${DEV}
     # In theory we could e.g. wipe the bootloader setup on the primary disk, then reboot;
     # but for now let's just sanity test that the install command executes.
+    partprobe ${DEV}
+    lsblk ${DEV}
     echo "ok install"
     ;;
   *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;

--- a/tests/kolainst/install
+++ b/tests/kolainst/install
@@ -23,7 +23,6 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     podman run --rm -ti --privileged --pid=host --net=none -v /usr/bin/bootc:/usr/bin/bootc ${IMAGE} bootc install --karg=foo=bar ${DEV}
     # In theory we could e.g. wipe the bootloader setup on the primary disk, then reboot;
     # but for now let's just sanity test that the install command executes.
-    partprobe ${DEV}
     lsblk ${DEV}
     echo "ok install"
     ;;


### PR DESCRIPTION
install: Factor out some options

Prep for `install-to-filesystem` which will accept an already
mounted fs and not a block device.

---

install: Actually honor provided kargs

Oops.  Seems like clap's attribute stuff suppresses unused
variable warnings.

---

install: More refactoring

Prep for adding `install-to-filesystem`.

- Split up options structure further
- Gather more things into global immutable `State`
- Add helper function to prepare `State`
- Tease back apart "kargs needed for rootfs" and "kargs specified by user"

---

