### PR TITLE
install: Add and use `MountSpec` abstraction for `/boot`

### DIFF
--- a/lib/src/bootloader.rs
+++ b/lib/src/bootloader.rs
@@ -51,7 +51,7 @@ fn install_grub2_efi(efidir: &Dir, uuid: &str) -> Result<()> {
 pub(crate) fn install_via_bootupd(
     device: &Utf8Path,
     rootfs: &Utf8Path,
-    boot_uuid: &uuid::Uuid,
+    boot_uuid: &str,
 ) -> Result<()> {
     Task::new_and_run(
         "Running bootupctl to install bootloader",


### PR DESCRIPTION
Prep for `install-to-filesystem`; rather than maintaining data about filesystems like `/boot` in an ad-hoc way, add a little structure which is equivalent to a subset of an `/etc/fstab` entry.

Right now we require a UUID for `/boot`.