### PR TITLE
Add `install-to-filesystem`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,16 @@ prefix ?= /usr
 all:
 	cargo build --release
     
+all-test:
+	cargo build --release --all-features
+
 install:
 	install -D -t $(DESTDIR)$(prefix)/bin target/release/bootc
 
 bin-archive: all
+	$(MAKE) install DESTDIR=tmp-install && tar --zstd -C tmp-install -cf bootc.tar.zst . && rm tmp-install -rf
+
+test-bin-archive: all-test
 	$(MAKE) install DESTDIR=tmp-install && tar --zstd -C tmp-install -cf bootc.tar.zst . && rm tmp-install -rf
 
 install-kola-tests:

--- a/ci/Dockerfile.fcos
+++ b/ci/Dockerfile.fcos
@@ -3,7 +3,7 @@
 FROM quay.io/coreos-assembler/fcos-buildroot:testing-devel as builder
 WORKDIR /src
 COPY . .
-RUN make bin-archive
+RUN make test-bin-archive
 
 FROM quay.io/fedora/fedora-coreos:testing-devel
 COPY --from=builder /src/bootc.tar.zst /tmp

--- a/ci/run-kola.sh
+++ b/ci/run-kola.sh
@@ -34,6 +34,6 @@ if test -z "${BASE_QEMU_IMAGE:-}"; then
     coreos-installer download -p qemu -f qcow2.xz --decompress
     BASE_QEMU_IMAGE="$(echo *.qcow2)"
 fi
-kola run --oscontainer ostree-unverified-registry:${TARGET_IMAGE} --qemu-image "./${BASE_QEMU_IMAGE}" "${kola_args[@]}" ext.bootc.'*'
+cosa kola run --oscontainer ostree-unverified-registry:${TARGET_IMAGE} --qemu-image "./${BASE_QEMU_IMAGE}" "${kola_args[@]}" ext.bootc.'*'
 
 echo "ok kola bootc"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -23,6 +23,7 @@ libc = "^0.2"
 once_cell = "1.9"
 openssl = "^0.10"
 nix = ">= 0.24, < 0.26"
+regex = "1.7.1"
 serde = { features = ["derive"], version = "1.0.125" }
 serde_json = "1.0.64"
 serde_with = ">= 1.9.4, < 2"

--- a/lib/src/bootloader.rs
+++ b/lib/src/bootloader.rs
@@ -15,6 +15,8 @@ pub(crate) const IGNITION_VARIABLE: &str = "$ignition_firstboot";
 const GRUB_BOOT_UUID_FILE: &str = "bootuuid.cfg";
 const STATIC_GRUB_CFG: &str = include_str!("grub.cfg");
 const STATIC_GRUB_CFG_EFI: &str = include_str!("grub-efi.cfg");
+/// The name of the mountpoint for efi (as a subdirectory of /boot, or at the toplevel)
+pub(crate) const EFI_DIR: &str = "efi";
 
 fn install_grub2_efi(efidir: &Dir, uuid: &str) -> Result<()> {
     let mut vendordir = None;
@@ -64,7 +66,7 @@ pub(crate) fn install_via_bootupd(
     let bootfs = &rootfs.join("boot");
 
     {
-        let efidir = Dir::open_ambient_dir(&bootfs.join("efi"), cap_std::ambient_authority())?;
+        let efidir = Dir::open_ambient_dir(bootfs.join("efi"), cap_std::ambient_authority())?;
         install_grub2_efi(&efidir, &grub2_uuid_contents)?;
     }
 

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -82,6 +82,13 @@ pub(crate) enum TestingOpts {
     RunPrivilegedIntegration {},
     /// Execute integration tests that target a not-privileged ostree container
     RunContainerIntegration {},
+    /// Block device setup for testing
+    PrepTestInstallFilesystem { blockdev: Utf8PathBuf },
+    /// e2e test of install-to-filesystem
+    TestInstallFilesystem {
+        image: String,
+        blockdev: Utf8PathBuf,
+    },
 }
 
 /// Deploy and upgrade via bootable container images.
@@ -99,6 +106,9 @@ pub(crate) enum Opt {
     /// Install to the target block device
     #[cfg(feature = "install")]
     Install(crate::install::InstallOpts),
+    /// Install to the target filesystem.
+    #[cfg(feature = "install")]
+    InstallToFilesystem(crate::install::InstallToFilesystemOpts),
     /// Internal integration testing helpers.
     #[clap(hide(true), subcommand)]
     #[cfg(feature = "internal-testing-api")]
@@ -336,6 +346,8 @@ where
         Opt::Switch(opts) => switch(opts).await,
         #[cfg(feature = "install")]
         Opt::Install(opts) => crate::install::install(opts).await,
+        #[cfg(feature = "install")]
+        Opt::InstallToFilesystem(opts) => crate::install::install_to_filesystem(opts).await,
         Opt::Status(opts) => super::status::status(opts).await,
         #[cfg(feature = "internal-testing-api")]
         Opt::InternalTests(opts) => crate::privtests::run(opts).await,

--- a/lib/src/ignition.rs
+++ b/lib/src/ignition.rs
@@ -313,7 +313,7 @@ mod tests {
             (false, "sha512-cdaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f")
         ];
         for (valid, hash_arg) in &hash_args {
-            let hasher = IgnitionHash::from_str(&hash_arg).unwrap();
+            let hasher = IgnitionHash::from_str(hash_arg).unwrap();
             let mut rd = std::io::Cursor::new(&input);
             assert!(hasher.validate(&mut rd).is_ok() == *valid);
         }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -33,6 +33,8 @@ pub(crate) mod ignition;
 #[cfg(feature = "install")]
 mod install;
 #[cfg(feature = "install")]
+pub(crate) mod mount;
+#[cfg(feature = "install")]
 mod podman;
 #[cfg(feature = "install")]
 mod task;

--- a/lib/src/mount.rs
+++ b/lib/src/mount.rs
@@ -1,0 +1,38 @@
+//! Helpers for interacting with mountpoints
+
+use std::process::Command;
+
+use anyhow::{anyhow, Context, Result};
+use camino::Utf8Path;
+use fn_error_context::context;
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) struct Filesystem {
+    pub(crate) source: String,
+    pub(crate) uuid: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+pub(crate) struct Findmnt {
+    pub(crate) filesystems: Vec<Filesystem>,
+}
+
+#[context("Inspecting filesystem {path}")]
+pub(crate) fn inspect_filesystem(path: &Utf8Path) -> Result<Filesystem> {
+    tracing::debug!("Inspecting {path}");
+    let o = Command::new("findmnt")
+        .args(["-J", "--output-all", path.as_str()])
+        .output()?;
+    let st = o.status;
+    if !st.success() {
+        anyhow::bail!("findmnt {path} failed: {st:?}");
+    }
+    let o: Findmnt = serde_json::from_reader(std::io::Cursor::new(&o.stdout))
+        .context("Parsing findmnt output")?;
+    o.filesystems
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow!("findmnt returned no data for {path}"))
+}

--- a/lib/src/privtests.rs
+++ b/lib/src/privtests.rs
@@ -114,6 +114,52 @@ pub(crate) fn impl_run_container() -> Result<()> {
     Ok(())
 }
 
+#[context("Container tests")]
+fn prep_test_install_filesystem(blockdev: &Utf8Path) -> Result<tempfile::TempDir> {
+    let sh = Shell::new()?;
+    // Arbitrarily larger partition offsets
+    let efipn = "5";
+    let bootpn = "6";
+    let rootpn = "7";
+    let mountpoint_dir = tempfile::tempdir()?;
+    let mountpoint: &Utf8Path = mountpoint_dir.path().try_into().unwrap();
+    // Create the partition setup; we add some random empty partitions for 2,3,4 just to exercise things
+    cmd!(
+        sh,
+        "sgdisk -Z {blockdev} -n 1:0:+1M -c 1:BIOS-BOOT -t 1:21686148-6449-6E6F-744E-656564454649 -n 2:0:+3M -n 3:0:+2M -n 4:0:+5M -n {efipn}:0:+127M -c {efipn}:EFI-SYSTEM -t ${efipn}:C12A7328-F81F-11D2-BA4B-00A0C93EC93B -n {bootpn}:0:+510M -c {bootpn}:boot -n {rootpn}:0:0 -c {rootpn}:root -t {rootpn}:0FC63DAF-8483-4772-8E79-3D69D8477DE4"
+    )
+    .run()?;
+    // Create filesystems and mount
+    cmd!(sh, "mkfs.ext4 {blockdev}{bootpn}").run()?;
+    cmd!(sh, "mkfs.ext4 {blockdev}{rootpn}").run()?;
+    cmd!(sh, "mkfs.fat {blockdev}{efipn}").run()?;
+    cmd!(sh, "mount {blockdev}{rootpn} {mountpoint}").run()?;
+    cmd!(sh, "mkdir {mountpoint}/boot").run()?;
+    cmd!(sh, "mount {blockdev}{bootpn} {mountpoint}/boot").run()?;
+    let efidir = crate::bootloader::EFI_DIR;
+    cmd!(sh, "mkdir {mountpoint}/boot/{efidir}").run()?;
+    cmd!(sh, "mount {blockdev}{efipn} {mountpoint}/boot/{efidir}").run()?;
+
+    Ok(mountpoint_dir)
+}
+
+#[context("Container tests")]
+fn test_install_filesystem(image: &str, blockdev: &Utf8Path) -> Result<()> {
+    let sh = Shell::new()?;
+
+    let mountpoint_dir = prep_test_install_filesystem(blockdev)?;
+    let mountpoint: &Utf8Path = mountpoint_dir.path().try_into().unwrap();
+
+    // And run the install
+    cmd!(sh, "podman run --rm --privileged --pid=host --net=none --env=RUST_LOG -v /usr/bin/bootc:/usr/bin/bootc -v {mountpoint}:/target-root {image} bootc install-to-filesystem /target-root").run()?;
+
+    cmd!(sh, "umount -R {mountpoint}").run()?;
+
+    drop(mountpoint);
+
+    Ok(())
+}
+
 pub(crate) async fn run(opts: TestingOpts) -> Result<()> {
     match opts {
         TestingOpts::RunPrivilegedIntegration {} => {
@@ -122,6 +168,14 @@ pub(crate) async fn run(opts: TestingOpts) -> Result<()> {
         }
         TestingOpts::RunContainerIntegration {} => {
             tokio::task::spawn_blocking(impl_run_container).await?
+        }
+        TestingOpts::PrepTestInstallFilesystem { blockdev } => {
+            tokio::task::spawn_blocking(move || prep_test_install_filesystem(&blockdev).map(|_| ()))
+                .await?
+        }
+        TestingOpts::TestInstallFilesystem { image, blockdev } => {
+            crate::cli::ensure_self_unshared_mount_namespace().await?;
+            tokio::task::spawn_blocking(move || test_install_filesystem(&image, &blockdev)).await?
         }
     }
 }

--- a/tests/kolainst/install
+++ b/tests/kolainst/install
@@ -25,6 +25,12 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     # but for now let's just sanity test that the install command executes.
     lsblk ${DEV}
     echo "ok install"
+
+    # Now test install-to-filesystem
+    # Wipe the device
+    ls ${DEV}* | tac | xargs wipefs -af
+    # This prepares the device and also runs podman directliy
+    bootc internal-tests test-install-filesystem ${IMAGE} ${DEV}
     ;;
   *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
 esac


### PR DESCRIPTION
Add `install-to-filesystem`

This will address the use case of having external code set up
the block devices and (empty) filesystems.  For example, one could
use a different privileged container, Anaconda, etc.

Closes: #54

Signed-off-by: Colin Walters <walters@verbum.org>

---

ci: Enable all features

Signed-off-by: Colin Walters <walters@verbum.org>

---

ci: Use `cosa kola` to pick up `ARTIFACT_DIR` handling

So I can see the logs in Prow.

Signed-off-by: Colin Walters <walters@verbum.org>

---

