### PR TITLE
xtask: Inject timestamp into version

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/xtask.rs"
 [dependencies]
 anyhow = "1.0.68"
 camino = "1.0"
+chrono = { version = "0.4.23", default_features = false, features = ["std"] }
 fn-error-context = "0.2.0"
 tempfile = "3.3"
 xshell = { version = "0.2" }

--- a/xtask/src/xtask.rs
+++ b/xtask/src/xtask.rs
@@ -66,6 +66,17 @@ fn gitrev(sh: &Shell) -> Result<String> {
     }
 }
 
+/// Return a string formatted version of the git commit timestamp, up to the minute
+/// but not second because, well, we're not going to build more than once a second.
+#[context("Finding git timestamp")]
+fn git_timestamp(sh: &Shell) -> Result<String> {
+    let ts = cmd!(sh, "git show --format=%ct").read()?;
+    let ts = ts.trim().parse::<i64>()?;
+    let ts = chrono::NaiveDateTime::from_timestamp_opt(ts, 0)
+        .ok_or_else(|| anyhow::anyhow!("Failed to parse timestamp"))?;
+    Ok(ts.format("%Y%m%d%H%M").to_string())
+}
+
 struct Package {
     version: String,
     srcpath: Utf8PathBuf,
@@ -74,6 +85,9 @@ struct Package {
 #[context("Packaging")]
 fn impl_package(sh: &Shell) -> Result<Package> {
     let v = gitrev(sh)?;
+    let timestamp = git_timestamp(sh)?;
+    // We always inject the timestamp first to ensure that newer is better.
+    let v = format!("{timestamp}.{v}");
     let namev = format!("{NAME}-{v}");
     let p = Utf8Path::new("target").join(format!("{namev}.tar.zstd"));
     let o = File::create(&p)?;


### PR DESCRIPTION
I was hitting an issue with our COPR builds where we were getting *earlier* builds because the git hash was the first component of the version, and the leading numbers there don't increment, and RPM wants higher versions.

Force newer-is-better by injecting the date (up to the minute, not second because we're not going to build more than one a second).