### PR TITLE
Tweak default tracing output

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,4 +24,4 @@ libc = "0.2.92"
 tokio = { version = "1", features = ["macros"] }
 log = "0.4.0"
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,4 +24,4 @@ libc = "0.2.92"
 tokio = { version = "1", features = ["macros"] }
 log = "0.4.0"
 tracing = "0.1"
-tracing-subscriber = "0.2.17"
+tracing-subscriber = "0.3"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,7 +5,19 @@
 use anyhow::Result;
 
 async fn run() -> Result<()> {
-    tracing_subscriber::fmt::init();
+    // Don't include timestamps and such because they're not really useful and
+    // too verbose, and plus several log targets such as journald will already
+    // include timestamps.
+    let format = tracing_subscriber::fmt::format()
+        .without_time()
+        .with_target(false)
+        .compact();
+    // Log to stderr by default
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .event_format(format)
+        .with_writer(std::io::stderr)
+        .init();
     tracing::trace!("starting");
     bootc_lib::cli::run_from_iter(std::env::args()).await
 }
@@ -13,7 +25,7 @@ async fn run() -> Result<()> {
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     if let Err(e) = run().await {
-        eprintln!("error: {:#}", e);
+        tracing::error!("{:#}", e);
         std::process::exit(1);
     }
 }


### PR DESCRIPTION
cli: Update `tracing-subscriber` to 0.3

On general principle, but specifically it has better APIs
for `EnvFilter`.

Signed-off-by: Colin Walters <walters@verbum.org>

---

Tweak default tracing output

Do log `info` level by default, but quiet the output format.
Prep for more use of tracing.

Signed-off-by: Colin Walters <walters@verbum.org>

---

