### PR TITLE
install: Add systemd-style drop-in config files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ all-test:
 
 install:
 	install -D -t $(DESTDIR)$(prefix)/bin target/release/bootc
+	install -D -t $(DESTDIR)$(prefix)/lib/bootc/install lib/src/install/*.toml
 
 bin-archive: all
 	$(MAKE) install DESTDIR=tmp-install && tar --zstd -C tmp-install -cf bootc.tar.zst . && rm tmp-install -rf

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -20,6 +20,7 @@ fn-error-context = "0.2.0"
 gvariant = "0.4.0"
 indicatif = "0.17.0"
 libc = "^0.2"
+liboverdrop = "0.1.0"
 once_cell = "1.9"
 openssl = "^0.10"
 nix = ">= 0.24, < 0.26"
@@ -32,6 +33,7 @@ tokio = { features = ["io-std", "time", "process", "rt", "net"], version = ">= 1
 tokio-util = { features = ["io-util"], version = "0.7" }
 tracing = "0.1"
 tempfile = "3.3.0"
+toml = "0.7.2"
 xshell = { version = "0.2", optional = true }
 uuid = { version = "1.2.2", features = ["v4"] }
 

--- a/lib/src/install/00-defaults.toml
+++ b/lib/src/install/00-defaults.toml
@@ -1,0 +1,3 @@
+# The default configuration for installations.
+[install]
+root-fs-type = "xfs"

--- a/lib/src/privtests.rs
+++ b/lib/src/privtests.rs
@@ -151,7 +151,7 @@ fn test_install_filesystem(image: &str, blockdev: &Utf8Path) -> Result<()> {
     let mountpoint: &Utf8Path = mountpoint_dir.path().try_into().unwrap();
 
     // And run the install
-    cmd!(sh, "podman run --rm --privileged --pid=host --net=none --env=RUST_LOG -v /usr/bin/bootc:/usr/bin/bootc -v {mountpoint}:/target-root {image} bootc install-to-filesystem /target-root").run()?;
+    cmd!(sh, "podman run --rm --privileged --pid=host --net=none --env=RUST_LOG -v /usr/bin/bootc:/usr/bin/bootc -v /usr/lib/bootc:/usr/lib/bootc -v {mountpoint}:/target-root {image} bootc install-to-filesystem /target-root").run()?;
 
     cmd!(sh, "umount -R {mountpoint}").run()?;
 

--- a/tests/kolainst/install
+++ b/tests/kolainst/install
@@ -20,7 +20,7 @@ cd $(mktemp -d)
 
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "")
-    podman run --rm -ti --privileged --pid=host --net=none -v /usr/bin/bootc:/usr/bin/bootc ${IMAGE} bootc install --karg=foo=bar ${DEV}
+    podman run --rm -ti --privileged --pid=host --net=none -v /usr/bin/bootc:/usr/bin/bootc -v /usr/lib/bootc:/usr/lib/bootc ${IMAGE} bootc install --karg=foo=bar ${DEV}
     # In theory we could e.g. wipe the bootloader setup on the primary disk, then reboot;
     # but for now let's just sanity test that the install command executes.
     lsblk ${DEV}


### PR DESCRIPTION
Add support for `/usr/lib/bootc/install/*.toml`
and `/etc/bootc/install/*.toml`
and `/run/bootc/install/*.toml` etc. which define config files for the install process.

Use this to configure the root filesystem type instead of hardcoding it.  We still default to xfs but it's now trivial for an OS/distribution to drop-in an override (or just edit the default toml).  Additionally derived builds can do so just as easily.

We then drop the `impl Default for Filesystem` so that the default isn't hardcoded in the binary anymore.