### PR TITLE
ci: Switch to `make test-bin-archive`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,12 @@ jobs:
         with:
           key: "build"
       - name: Build
-        run: cargo build --release --features internal-testing-api
+        run: make test-bin-archive
       - name: Upload binary
         uses: actions/upload-artifact@v2
         with:
-          name: bootc
-          path: target/release/bootc
+          name: bootc.tar.zst
+          path: target/bootc.tar.zst
   build-minimum-toolchain:
     name: "Build using MSRV"
     runs-on: ubuntu-latest
@@ -122,9 +122,9 @@ jobs:
       - name: Download
         uses: actions/download-artifact@v2
         with:
-          name: bootc
+          name: bootc.tar.zst
       - name: Install
-        run: sudo install bootc /usr/bin && rm -v bootc
+        run: sudo tar -C / -xvf bootc.tar.zst
       - name: Integration tests
         run: sudo podman run --rm -ti --privileged -v /run/systemd:/run/systemd -v /:/run/host -v /usr/bin/bootc:/usr/bin/bootc --pid=host quay.io/fedora/fedora-coreos:testing-devel bootc internal-tests run-privileged-integration
   container-tests:
@@ -136,8 +136,8 @@ jobs:
       - name: Download
         uses: actions/download-artifact@v2
         with:
-          name: bootc
+          name: bootc.tar.zst
       - name: Install
-        run: install bootc /usr/bin && rm -v bootc
+        run: sudo tar -C / -xvf bootc.tar.zst
       - name: Integration tests
         run: bootc internal-tests run-container-integration

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ install:
 	install -D -t $(DESTDIR)$(prefix)/bin target/release/bootc
 
 bin-archive: all
-	$(MAKE) install DESTDIR=tmp-install && tar --zstd -C tmp-install -cf bootc.tar.zst . && rm tmp-install -rf
+	$(MAKE) install DESTDIR=tmp-install && tar --zstd -C tmp-install -cf target/bootc.tar.zst . && rm tmp-install -rf
 
 test-bin-archive: all-test
-	$(MAKE) install DESTDIR=tmp-install && tar --zstd -C tmp-install -cf bootc.tar.zst . && rm tmp-install -rf
+	$(MAKE) install DESTDIR=tmp-install && tar --zstd -C tmp-install -cf target/bootc.tar.zst . && rm tmp-install -rf
 
 install-kola-tests:
 	install -D -t $(DESTDIR)$(prefix)/lib/coreos-assembler/tests/kola/bootc tests/kolainst/*

--- a/ci/Dockerfile.fcos
+++ b/ci/Dockerfile.fcos
@@ -6,5 +6,5 @@ COPY . .
 RUN make test-bin-archive
 
 FROM quay.io/fedora/fedora-coreos:testing-devel
-COPY --from=builder /src/bootc.tar.zst /tmp
+COPY --from=builder /src/target/bootc.tar.zst /tmp
 RUN tar -xvf /tmp/bootc.tar.zst && ostree container commit 


### PR DESCRIPTION
build: Install bin-archive in target/

To avoid polluting the toplevel.

---

ci: Switch to `make test-bin-archive`

Right now we only install a single binary, but in the future
that will change (e.g. systemd units, config files).

---

