### PR TITLE
xtask: Fix package builds

### DIFF
--- a/xtask/src/xtask.rs
+++ b/xtask/src/xtask.rs
@@ -70,7 +70,7 @@ fn gitrev(sh: &Shell) -> Result<String> {
 /// but not second because, well, we're not going to build more than once a second.
 #[context("Finding git timestamp")]
 fn git_timestamp(sh: &Shell) -> Result<String> {
-    let ts = cmd!(sh, "git show --format=%ct").read()?;
+    let ts = cmd!(sh, "git show -s --format=%ct").read()?;
     let ts = ts.trim().parse::<i64>()?;
     let ts = chrono::NaiveDateTime::from_timestamp_opt(ts, 0)
         .ok_or_else(|| anyhow::anyhow!("Failed to parse timestamp"))?;


### PR DESCRIPTION
No idea how it worked before; we don't want to include the diff output which can lead to us failing to parse an integer:

```
error: Packaging

Caused by:
    0: Finding git timestamp
    1: invalid digit found in string
```