### PR TITLE
spec: Add `/usr/lib/bootc` to installed files

### DIFF
--- a/contrib/packaging/bootc.spec
+++ b/contrib/packaging/bootc.spec
@@ -28,6 +28,7 @@ BuildRequires: systemd-devel
 %license LICENSE-APACHE LICENSE-MIT
 %doc README.md
 %{_bindir}/bootc
+%{_prefix}/lib/bootc
 
 %prep
 %autosetup -p1 -Sgit


### PR DESCRIPTION
Sigh, so annoying that RPM makes one allowlist installed files.