### PR TITLE
takeover installs: prep0

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.63.0"
 [dependencies]
 anyhow = "1.0"
 camino = { version = "1.0.4", features = ["serde1"] }
-ostree-ext = "0.10.5"
+ostree-ext = "0.10.6"
 clap = { version= "3.2", features = ["derive"] }
 clap_mangen = { version = "0.1", optional = true }
 cap-std-ext = "1.0.1"

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -312,19 +312,19 @@ impl SourceInfo {
     }
 }
 
-mod config {
+pub(crate) mod config {
     use super::*;
 
     /// The toplevel config entry for installation configs stored
     /// in bootc/install (e.g. /etc/bootc/install/05-custom.toml)
-    #[derive(Debug, Deserialize, Default)]
+    #[derive(Debug, Clone, Serialize, Deserialize, Default)]
     #[serde(deny_unknown_fields)]
     pub(crate) struct InstallConfigurationToplevel {
         pub(crate) install: Option<InstallConfiguration>,
     }
 
     /// The serialized [install] section
-    #[derive(Debug, Deserialize, Default)]
+    #[derive(Debug, Clone, Serialize, Deserialize, Default)]
     #[serde(rename = "install", rename_all = "kebab-case", deny_unknown_fields)]
     pub(crate) struct InstallConfiguration {
         pub(crate) root_fs_type: Option<super::baseline::Filesystem>,

--- a/lib/src/lsm.rs
+++ b/lib/src/lsm.rs
@@ -1,3 +1,5 @@
+use std::fs::File;
+use std::io::Write;
 use std::os::unix::process::CommandExt;
 use std::path::Path;
 use std::process::Command;
@@ -76,6 +78,20 @@ pub(crate) fn container_setup_selinux() -> Result<()> {
             .args(["selinuxfs", "-t", "selinuxfs", path.as_str()])
             .run()?;
     }
+    Ok(())
+}
+
+#[context("Setting SELinux permissive mode")]
+#[allow(dead_code)]
+#[cfg(feature = "install")]
+pub(crate) fn selinux_set_permissive() -> Result<()> {
+    let enforce_path = &Utf8Path::new(SELINUXFS).join("enforce");
+    if !enforce_path.exists() {
+        return Ok(());
+    }
+    let mut f = File::open(enforce_path)?;
+    f.write_all(b"0")?;
+    tracing::debug!("Set SELinux permissive mode");
     Ok(())
 }
 


### PR DESCRIPTION
install: Make config module `pub(crate)` and configs serializable

Prep for takeover installs.

---

lsm: Add an API to set SELinux permissive

This is going to be needed for takeover installs.  There's
no point to trying to keep the LSM state running through
the whole thing because we're going to replace the OS anyways.

---

Bump requirement to latest ostree-ext

Prep for takeover installs.

---

