### PR TITLE
cli: Add an alias `update` for `upgrade`

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -101,6 +101,7 @@ pub(crate) enum TestingOpts {
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum Opt {
     /// Look for updates to the booted container image.
+    #[clap(alias = "update")]
     Upgrade(UpgradeOpts),
     /// Target a new container image reference to boot.
     Switch(SwitchOpts),

--- a/lib/src/privtests.rs
+++ b/lib/src/privtests.rs
@@ -105,11 +105,13 @@ pub(crate) fn impl_run_container() -> Result<()> {
     let stout = cmd!(sh, "bootc status").read()?;
     assert!(stout.contains("Running in a container (ostree base)."));
     drop(stout);
-    let o = Command::new("bootc").arg("upgrade").output()?;
-    let st = o.status;
-    assert!(!st.success());
-    let stderr = String::from_utf8(o.stderr)?;
-    assert!(stderr.contains("this command requires a booted host system"));
+    for c in ["upgrade", "update"] {
+        let o = Command::new("bootc").arg(c).output()?;
+        let st = o.status;
+        assert!(!st.success());
+        let stderr = String::from_utf8(o.stderr)?;
+        assert!(stderr.contains("this command requires a booted host system"));
+    }
     println!("ok container integration testing");
     Ok(())
 }


### PR DESCRIPTION
yum/dnf does this, I think it's a friendly thing to do.  I actually typed `bootc update` and got reminded to do this.