### PR TITLE
Two crate bumps and use `fsfreeze`

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,7 +19,7 @@ platforms = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "powerpc64
 [dependencies]
 anyhow = "1.0"
 bootc-lib = { version = "0.1", path = "../lib" }
-clap = "3.2"
+clap = "4.2"
 libc = "0.2.92"
 tokio = { version = "1", features = ["macros"] }
 log = "0.4.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -12,8 +12,8 @@ rust-version = "1.64.0"
 anyhow = "1.0"
 camino = { version = "1.0.4", features = ["serde1"] }
 ostree-ext = "0.10.6"
-clap = { version= "3.2", features = ["derive"] }
-clap_mangen = { version = "0.1", optional = true }
+clap = { version= "4.2", features = ["derive"] }
+clap_mangen = { version = "0.2", optional = true }
 cap-std-ext = "1.0.1"
 hex = "^0.4"
 fn-error-context = "0.2.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -11,10 +11,10 @@ rust-version = "1.64.0"
 [dependencies]
 anyhow = "1.0"
 camino = { version = "1.0.4", features = ["serde1"] }
-ostree-ext = "0.10.6"
+ostree-ext = "0.11"
 clap = { version= "4.2", features = ["derive"] }
 clap_mangen = { version = "0.2", optional = true }
-cap-std-ext = "1.0.1"
+cap-std-ext = "2"
 hex = "^0.4"
 fn-error-context = "0.2.0"
 gvariant = "0.4.0"
@@ -25,7 +25,7 @@ once_cell = "1.9"
 openssl = "^0.10"
 nix = ">= 0.24, < 0.26"
 regex = "1.7.1"
-rustix = { "version" = "0.36", features = ["thread"] }
+rustix = { "version" = "0.37", features = ["thread", "process"] }
 serde = { features = ["derive"], version = "1.0.125" }
 serde_json = "1.0.64"
 serde_with = ">= 1.9.4, < 2"

--- a/lib/src/docgen.rs
+++ b/lib/src/docgen.rs
@@ -36,6 +36,10 @@ fn generate_one(directory: &Utf8Path, cmd: Command) -> Result<()> {
 
     for subcmd in cmd.get_subcommands().filter(|c| !c.is_hide_set()) {
         let subname = format!("{}-{}", name, subcmd.get_name());
+        // SAFETY: Latest clap 4 requires names are &'static - this is
+        // not long-running production code, so we just leak the names here.
+        let subname = &*std::boxed::Box::leak(subname.into_boxed_str());
+        let subcmd = subcmd.clone().name(subname).alias(subname).version(version);
         generate_one(directory, subcmd.clone().name(subname).version(version))?;
     }
     Ok(())

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -20,7 +20,7 @@ use camino::Utf8PathBuf;
 use cap_std::fs::Dir;
 use cap_std_ext::cap_std;
 use cap_std_ext::prelude::CapStdExtDirExt;
-use cap_std_ext::rustix::fs::MetadataExt;
+use rustix::fs::MetadataExt;
 
 use fn_error_context::context;
 use ostree::gio;
@@ -518,7 +518,7 @@ async fn initialize_ostree_root_from_self(
         .next()
         .ok_or_else(|| anyhow::anyhow!("Failed to find deployment"))?;
     // SAFETY: There must be a path
-    let path = sysroot.deployment_dirpath(&deployment).unwrap();
+    let path = sysroot.deployment_dirpath(&deployment);
     let root = rootfs_dir
         .open_dir(path.as_str())
         .context("Opening deployment dir")?;
@@ -531,7 +531,7 @@ async fn initialize_ostree_root_from_self(
     writeln!(f, "{}", root_setup.boot.to_fstab())?;
     f.flush()?;
 
-    let uname = cap_std_ext::rustix::process::uname();
+    let uname = rustix::process::uname();
 
     let aleph = InstallAleph {
         image: src_imageref.imgref.name.clone(),

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -670,7 +670,7 @@ pub(crate) fn finalize_filesystem(fs: &Utf8Path) -> Result<()> {
         .run()?;
     // Finally, freezing (and thawing) the filesystem will flush the journal, which means the next boot is clean.
     for a in ["-f", "-u"] {
-        Task::new("Flushing filesystem journal", "xfs_freeze")
+        Task::new("Flushing filesystem journal", "fsfreeze")
             .quiet()
             .args([a, fs.as_str()])
             .run()?;

--- a/lib/src/install/baseline.rs
+++ b/lib/src/install/baseline.rs
@@ -17,7 +17,7 @@ use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use cap_std::fs::Dir;
 use cap_std_ext::cap_std;
-use clap::ArgEnum;
+use clap::ValueEnum;
 use fn_error_context::context;
 use serde::{Deserialize, Serialize};
 

--- a/lib/src/privtests.rs
+++ b/lib/src/privtests.rs
@@ -2,7 +2,6 @@ use std::process::Command;
 
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
-use cap_std_ext::rustix;
 use fn_error_context::context;
 use rustix::fd::AsFd;
 use xshell::{cmd, Shell};

--- a/lib/src/status.rs
+++ b/lib/src/status.rs
@@ -65,7 +65,7 @@ impl DeploymentStatus {
         let staged = deployment.is_staged();
         let pinned = deployment.is_pinned();
         let image = get_image_origin(deployment)?.1;
-        let checksum = deployment.csum().unwrap().to_string();
+        let checksum = deployment.csum().to_string();
         let deploy_serial = (!staged).then(|| deployment.bootserial().try_into().unwrap());
         let supported = deployment
             .origin()
@@ -119,7 +119,7 @@ pub(crate) async fn status(opts: super::cli::StatusOpts) -> Result<()> {
         return Ok(());
     }
     let sysroot = super::cli::get_locked_sysroot().await?;
-    let repo = &sysroot.repo().unwrap();
+    let repo = &sysroot.repo();
     let booted_deployment = sysroot.booted_deployment();
 
     let deployments = get_deployments(&sysroot, booted_deployment.as_ref(), opts.booted)?;


### PR DESCRIPTION
Update to clap 4.2

Just keeping up with things.

---

Update to ostree-ext 0.11, also bump rustix and cap-std-ext

This is similar to https://github.com/coreos/rpm-ostree/pull/4400

---

install: use fsfreeze, not xfs_freeze

More people are going to have util-linux installed than
have xfsprogs.  Reported via email.

Signed-off-by: Colin Walters <walters@verbum.org>

---

