### PR TITLE
Bump MSRV to 1.64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # Pinned toolchain for linting
-  ACTION_LINTS_TOOLCHAIN: 1.63.0
+  ACTION_LINTS_TOOLCHAIN: 1.64.0
 
 jobs:
   tests:

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ name = "bootc-lib"
 readme = "README.md"
 repository = "https://github.com/cgwalters/bootc"
 version = "0.1.0"
-rust-version = "1.63.0"
+rust-version = "1.64.0"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
Because it's needed for more libraries.