### PR TITLE
cli: Add a `--check` flag for update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Required dependencies
+
+In order to build `bootc` you will need the following dependencies.
+
+Fedora: 
+```
+sudo dnf install ostree-libs ostree-devel
+```
+
+# Pre flight checks
+
+Makes sure you commented your code additions, then run 
+```
+cargo fmt
+cargo clippy
+```
+Make sure to apply any relevant suggestions. 
+


### PR DESCRIPTION
This simply pull the manifest of the iamge to see if any update and available. It could be named `--dry-run` but I wanted to be consistent with `rpm-ostree`.
Fixes #3