### PR TITLE
deploy: Use new ostree API to GC images

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.64.0"
 [dependencies]
 anyhow = "1.0"
 camino = { version = "1.0.4", features = ["serde1"] }
-ostree-ext = "0.11"
+ostree-ext = "0.11.2"
 clap = { version= "4.2", features = ["derive"] }
 clap_mangen = { version = "0.2", optional = true }
 cap-std-ext = "2"


### PR DESCRIPTION
This makes the whole system less stateful - we always prune unused images.