### PR TITLE
lib: Bump to ostree-ext 0.11.5

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.64.0"
 [dependencies]
 anyhow = "1.0"
 camino = { version = "1.0.4", features = ["serde1"] }
-ostree-ext = "0.11.2"
+ostree-ext = "0.11.5"
 clap = { version= "4.2", features = ["derive"] }
 clap_mangen = { version = "0.2", optional = true }
 cap-std-ext = "2"

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -283,6 +283,7 @@ async fn upgrade(opts: UpgradeOpts) -> Result<()> {
         let imgref = &OstreeImageReference::from(imgref.clone());
         let mut imp =
             ostree_container::store::ImageImporter::new(&sysroot.repo(), imgref, config).await?;
+        imp.require_bootable();
         match imp.prepare().await? {
             PrepareResult::AlreadyPresent(c) => {
                 println!(


### PR DESCRIPTION
And note the new `require_bootable()`, since we couldn't require that in the container image importer.