### PR TITLE
Two lint fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["cli", "lib", "xtask"]
+resolver = "2"
 
 [profile.dev]
 opt-level = 1 # No optimizations are too slow for us.

--- a/lib/src/privtests.rs
+++ b/lib/src/privtests.rs
@@ -157,8 +157,6 @@ fn test_install_filesystem(image: &str, blockdev: &Utf8Path) -> Result<()> {
 
     cmd!(sh, "umount -R {mountpoint}").run()?;
 
-    drop(mountpoint);
-
     Ok(())
 }
 


### PR DESCRIPTION
tests: Drop unnecessary `drop`

Newer rustc warns about this, dropping a reference does
nothing.  I think this code used to handle unmount via drop.

---

build-sys: Opt in to resolver = 2

This silences a warning from newer Rust.

---

