### PR TITLE
ci: Drop MSRV, move clippy/fmt into tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  # Pinned toolchain for linting
-  ACTION_LINTS_TOOLCHAIN: 1.64.0
 
 jobs:
   tests:
@@ -28,6 +26,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: "tests"
+      - name: cargo fmt (check)
+        run: cargo fmt -- --check -l
       - name: Build
         run: cargo test --no-run
       - name: Build lib without default features
@@ -40,6 +40,8 @@ jobs:
         run: cargo test -- --nocapture --quiet
       - name: Manpage generation
         run: mkdir -p target/man && cargo run --features=docgen -- man --directory target/man
+      - name: Clippy (non-gating)
+        run: cargo clippy
   build:
     runs-on: ubuntu-latest
     container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
@@ -58,33 +60,6 @@ jobs:
         with:
           name: bootc.tar.zst
           path: target/bootc.tar.zst
-  build-minimum-toolchain:
-    name: "Build using MSRV"
-    runs-on: ubuntu-latest
-    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Install deps
-        run: ./ci/installdeps.sh
-      - name: Detect crate MSRV
-        shell: bash
-        run: |
-          msrv=$(cargo metadata --format-version 1 --no-deps | \
-              jq -r '.packages[1].rust_version')
-          echo "Crate MSRV: $msrv"
-          echo "ACTION_MSRV_TOOLCHAIN=$msrv" >> $GITHUB_ENV
-      - name: Remove system Rust toolchain
-        run: dnf remove -y rust cargo
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env['ACTION_MSRV_TOOLCHAIN']  }}
-      - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: "min"
-      - name: cargo check
-        run: cargo check
   cargo-deny:
     runs-on: ubuntu-latest
     steps:
@@ -93,25 +68,6 @@ jobs:
       with:
         log-level: warn
         command: check bans sources licenses
-  linting:
-    name: "Lints, pinned toolchain"
-    runs-on: ubuntu-latest
-    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Install deps
-        run: ./ci/installdeps.sh
-      - name: Remove system Rust toolchain
-        run: dnf remove -y rust cargo
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env['ACTION_LINTS_TOOLCHAIN']  }}
-          components: rustfmt, clippy
-      - name: cargo fmt (check)
-        run: cargo fmt -- --check -l
-      - name: cargo clippy (warnings)
-        run: cargo clippy -- -D warnings
   privtest:
     name: "Privileged testing"
     needs: build


### PR DESCRIPTION
The MSRV is just too much churn to maintain, in practice let's roll with what's in Fedora.