### PR TITLE
install: Add some more error context

### DIFF
--- a/lib/src/blockdev.rs
+++ b/lib/src/blockdev.rs
@@ -40,6 +40,7 @@ impl Device {
     }
 }
 
+#[context("Failed to wipe {dev}")]
 pub(crate) fn wipefs(dev: &Utf8Path) -> Result<()> {
     Task::new_and_run(
         format!("Wiping device {dev}"),

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -763,6 +763,7 @@ async fn prepare_install(
         reexecute_self_for_selinux_if_needed(&source, config_opts.disable_selinux)?;
 
     let install_config = config::load_config()?;
+    tracing::debug!("Loaded install configuration");
 
     // Create our global (read-only) state which gets wrapped in an Arc
     // so we can pass it to worker threads too. Right now this just

--- a/lib/src/install/baseline.rs
+++ b/lib/src/install/baseline.rs
@@ -263,7 +263,8 @@ pub(crate) fn install_create_rootfs(
         "root",
         Some("0FC63DAF-8483-4772-8E79-3D69D8477DE4"),
     );
-    sgdisk.run()?;
+    sgdisk.run().context("Failed to run sgdisk")?;
+    tracing::debug!("Created partition table");
 
     // Reread the partition table
     {


### PR DESCRIPTION
`sgdisk` dropped out of my image when I was changing things. In retrospect the error message was relatively clear, but here's some error context I added while debugging.