### PR TITLE
lib: Bump to newer nix

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -25,7 +25,8 @@ libc = "^0.2"
 liboverdrop = "0.1.0"
 once_cell = "1.9"
 openssl = "^0.10"
-nix = ">= 0.24, < 0.26"
+# TODO drop this in favor of rustix
+nix = { version = "0.27", features = ["ioctl"] }
 regex = "1.7.1"
 rustix = { "version" = "0.38", features = ["thread", "fs", "system", "process"] }
 schemars = "0.8.6"


### PR DESCRIPTION
We only have this for the ioctl code which we copied from coreos-installer...would be good to port to rustix at some point.

But for now let's update to a newer nix.