### PR TITLE
Deps: Bump to latest kube/k8s-openapi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,6 @@ exclude-crate-paths = [ { name = "libz-sys", exclude = "src/zlib" },
                         # Test files that include binaries
                         { name = "system-deps", exclude = "src/tests" },
                         # This stuff is giant, trim unused versions
-                        { name = "k8s-openapi", exclude = "src/v1_20" },
-                        { name = "k8s-openapi", exclude = "src/v1_21" },
-                        { name = "k8s-openapi", exclude = "src/v1_22" },
-                        { name = "k8s-openapi", exclude = "src/v1_23" },
-                        { name = "k8s-openapi", exclude = "src/v1_24" },
-                        # We use 1.25
-                        { name = "k8s-openapi", exclude = "src/v1_26" },
+                        { name = "k8s-openapi", exclude = "src/v1_25" },
+                        { name = "k8s-openapi", exclude = "src/v1_27" },
                       ]

--- a/deny.toml
+++ b/deny.toml
@@ -2,7 +2,9 @@
 unlicensed = "deny"
 allow = ["Apache-2.0", "Apache-2.0 WITH LLVM-exception", "MIT", "BSD-3-Clause", "BSD-2-Clause", "Unicode-DFS-2016"]
 
-[bans]
+[[bans.deny]]
+# We want to require FIPS validation downstream, so we use openssl
+name = "ring"
 
 [sources]
 unknown-registry = "deny"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -20,8 +20,8 @@ hex = "^0.4"
 fn-error-context = "0.2.0"
 gvariant = "0.4.0"
 indicatif = "0.17.0"
-k8s-openapi = { version = "0.18.0", features = ["v1_25", "schemars"] }
-kube = { version = "0.83.0", features = ["runtime", "derive"] }
+k8s-openapi = { version = "0.20.0", features = ["v1_28", "schemars"] }
+kube = { version = "0.86.0", default-features = false, features = ["client", "openssl-tls", "runtime", "derive", "openssl-tls"] }
 libc = "^0.2"
 liboverdrop = "0.1.0"
 once_cell = "1.9"


### PR DESCRIPTION
On general principle; they trimmed their supported version set which reduces dep size.  But it also drops out some old things like `base64@0.13.1` (how many times does a base64 library really need to break semver?).