### PR TITLE
Add support for `--replace-mode=alongside` for ostree target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ lto = "yes"
 [workspace.dependencies]
 anyhow = "1.0.82"
 camino = "1.1.6"
-cap-std-ext = "4.0.2"
+cap-std-ext = "4.0.3"
 chrono = { version = "0.4.38", default-features = false }
 clap = "4.5.4"
 clap_mangen = { version = "0.2.20" }


### PR DESCRIPTION
Ironically our support for `--replace-mode=alongside` breaks when we're targeting an already extant ostree host, because when we first blow away the `/boot` directory, this means the ostree stack loses its knowledge that we're in a booted deployment, and will attempt to GC it...

https://github.com/ostreedev/ostree-rs-ext/pull/550/commits/8fa019bfa821303cfb7a7f069ae2320f4c3800fa is a key part of the fix for that.

However, a notable improvement we can do here is to grow this whole thing into a real "factory reset" mode, and this will be a compelling answer to
https://github.com/coreos/fedora-coreos-tracker/issues/399

To implement this though we need to support configuring the stateroot and not just hardcode `default`.