### PR TITLE
lib: Include license files when packaging

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -8,6 +8,8 @@ repository = "https://github.com/cgwalters/bootc"
 version = "0.1.0"
 rust-version = "1.64.0"
 
+include = ["/src", "LICENSE-APACHE", "LICENSE-MIT"]
+
 [dependencies]
 anyhow = "1.0"
 camino = { version = "1.0.4", features = ["serde1"] }

--- a/lib/LICENSE-APACHE
+++ b/lib/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/lib/LICENSE-MIT
+++ b/lib/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
While we're not shipping this on crates.io and probably won't soon, it's useful to be able to run a `cargo package` just in case.  The Fedora rust2rpm tool wants license files in the crate tarball.