### PR TITLE
install: Bail out if we detect we're running rootless

### DIFF
--- a/lib/src/containerenv.rs
+++ b/lib/src/containerenv.rs
@@ -16,6 +16,7 @@ pub(crate) struct ContainerExecutionInfo {
     pub(crate) id: String,
     pub(crate) image: String,
     pub(crate) imageid: String,
+    pub(crate) rootless: Option<String>,
 }
 
 /// Load and parse the `/run/.containerenv` file.

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -785,6 +785,10 @@ async fn prepare_install(
 
     // This command currently *must* be run inside a privileged container.
     let container_info = crate::containerenv::get_container_execution_info(&rootfs)?;
+    if let Some("1") = container_info.rootless.as_deref() {
+        anyhow::bail!("Cannot install from rootless podman; this command must be run as root");
+    }
+
     let source = SourceInfo::from_container(&container_info)?;
 
     ensure_var()?;


### PR DESCRIPTION
It's an easy mistake to make and the error message is less than obvious.