### PR TITLE
Rework build infra, add manpages into tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,9 @@ all-test:
 	cargo build --release --all-features
 
 install:
-	install -D -t $(DESTDIR)$(prefix)/bin target/release/bootc
-	install -D -t $(DESTDIR)$(prefix)/lib/bootc/install lib/src/install/*.toml
+	install -D -m 0755 -t $(DESTDIR)$(prefix)/bin target/release/bootc
+	install -D -m 0644 -t $(DESTDIR)$(prefix)/lib/bootc/install lib/src/install/*.toml
+	if test -d man; then install -D -m 0644 -t $(DESTDIR)$(prefix)/share/man/man8 man/*.8; fi
 
 bin-archive: all
 	$(MAKE) install DESTDIR=tmp-install && tar --zstd -C tmp-install -cf target/bootc.tar.zst . && rm tmp-install -rf

--- a/contrib/packaging/bootc.spec
+++ b/contrib/packaging/bootc.spec
@@ -7,8 +7,8 @@ Summary:        Boot containers
 
 License:        ASL 2.0
 URL:            https://github.com/containers/bootc
-Source0:        https://github.com/containers/bootc/releases/download/v%{version}/bootc-%{version}.tar.zstd
-Source1:        https://github.com/containers/bootc/releases/download/v%{version}/bootc-%{version}-vendor.tar.zstd
+Source0:        https://github.com/containers/bootc/releases/download/v%{version}/bootc-%{version}.tar.zst
+Source1:        https://github.com/containers/bootc/releases/download/v%{version}/bootc-%{version}-vendor.tar.zst
 
 BuildRequires: make
 BuildRequires: openssl-devel
@@ -29,6 +29,7 @@ BuildRequires: systemd-devel
 %doc README.md
 %{_bindir}/bootc
 %{_prefix}/lib/bootc
+%{_mandir}/man8/bootc*
 
 %prep
 %autosetup -p1 -Sgit

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -111,7 +111,16 @@ pub(crate) enum TestingOpts {
     },
 }
 
-/// Deploy and upgrade via bootable container images.
+/// Deploy and transactionally in-place with bootable container images.
+///
+/// The `bootc` project currently uses ostree-containers as a backend
+/// to support a model of bootable container images.  Once installed,
+/// whether directly via `bootc install` (executed as part of a container)
+/// or via another mechanism such as an OS installer tool, further
+/// updates can be pulled via e.g. `bootc upgrade`.
+///
+/// Changes in `/etc` and `/var` persist.
+///
 #[derive(Debug, Parser)]
 #[clap(name = "bootc")]
 #[clap(rename_all = "kebab-case")]


### PR DESCRIPTION
- Inject pre-generated manpages into the source tarball we make
- Ensure we use the git tag for version if there is one

Immediate motivation is making sure man pages end up in e.g. RPM builds.