### PR TITLE
More errcontext

### DIFF
--- a/lib/src/bootloader.rs
+++ b/lib/src/bootloader.rs
@@ -56,19 +56,15 @@ pub(crate) fn install_via_bootupd(
     rootfs: &Utf8Path,
     boot_uuid: &str,
 ) -> Result<()> {
-    Task::new_and_run(
-        "Running bootupctl to install bootloader",
-        "bootupctl",
-        [
-            "backend",
-            "install",
-            "--src-root",
-            "/",
-            "--device",
-            device.as_str(),
-            rootfs.as_str(),
-        ],
-    )?;
+    let verbose = std::env::var_os("BOOTC_BOOTLOADER_DEBUG").map(|_| "-vvvv");
+    let args = ["backend", "install"].into_iter().chain(verbose).chain([
+        "--src-root",
+        "/",
+        "--device",
+        device.as_str(),
+        rootfs.as_str(),
+    ]);
+    Task::new_and_run("Running bootupctl to install bootloader", "bootupctl", args)?;
 
     let grub2_uuid_contents = format!("set BOOT_UUID=\"{boot_uuid}\"\n");
 


### PR DESCRIPTION
bootloader: Add BOOTC_BOOTLOADER_DEBUG env var

To force on verbose tracing for bootupd to debug things.

---

bootloader: Add more error context

To debug a problem I hit.

---

