### PR TITLE
install: Relax restriction on separate /boot

### DIFF
--- a/lib/src/install/baseline.rs
+++ b/lib/src/install/baseline.rs
@@ -368,7 +368,8 @@ pub(crate) fn install_create_rootfs(
         device,
         rootfs,
         rootfs_fd,
-        boot,
+        rootfs_uuid: Some(root_uuid.to_string()),
+        boot: Some(boot),
         kargs,
         skip_finalize: false,
     })


### PR DESCRIPTION
For example, the current RHEL 9.2 VM images (KVM/cloud-init guest, and at least GCP) don't use a separate `/boot` by default (probably because they don't support LUKS for `/` like CoreOS systems do).