### PR TITLE
Drop k8s-openapi and kube crates

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -22,8 +22,6 @@ hex = "^0.4"
 fn-error-context = "0.2.0"
 gvariant = "0.4.0"
 indicatif = "0.17.0"
-k8s-openapi = { version = "0.20.0", features = ["v1_28", "schemars"] }
-kube = { version = "0.86.0", default-features = false, features = ["client", "openssl-tls", "runtime", "derive", "openssl-tls"] }
 libc = "^0.2"
 liboverdrop = "0.1.0"
 once_cell = "1.9"

--- a/lib/src/k8sapitypes.rs
+++ b/lib/src/k8sapitypes.rs
@@ -1,0 +1,28 @@
+//! Subset of API definitions for selected Kubernetes API types.
+//! We avoid dragging in all of k8s-openapi because it's *huge*.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Resource {
+    pub api_version: String,
+    pub kind: String,
+    #[serde(default)]
+    pub metadata: ObjectMeta,
+}
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ObjectMeta {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<BTreeMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub labels: Option<BTreeMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -33,6 +33,7 @@ mod containerenv;
 pub(crate) mod ignition;
 #[cfg(feature = "install")]
 mod install;
+mod k8sapitypes;
 #[cfg(feature = "install")]
 pub(crate) mod mount;
 #[cfg(feature = "install")]

--- a/lib/src/status.rs
+++ b/lib/src/status.rs
@@ -3,7 +3,6 @@ use std::collections::VecDeque;
 use crate::spec::{BootEntry, Host, HostSpec, HostStatus, ImageStatus};
 use crate::spec::{ImageReference, ImageSignature};
 use anyhow::{Context, Result};
-use k8s_openapi::apimachinery::pkg::apis::meta::v1 as k8smeta;
 use ostree::glib;
 use ostree_container::OstreeImageReference;
 use ostree_ext::container as ostree_container;
@@ -89,9 +88,9 @@ pub(crate) struct Deployments {
     pub(crate) other: VecDeque<ostree::Deployment>,
 }
 
-fn try_deserialize_timestamp(t: &str) -> Option<k8smeta::Time> {
+fn try_deserialize_timestamp(t: &str) -> Option<chrono::DateTime<chrono::Utc>> {
     match chrono::DateTime::parse_from_rfc3339(t).context("Parsing timestamp") {
-        Ok(t) => Some(k8smeta::Time(t.with_timezone(&chrono::Utc))),
+        Ok(t) => Some(t.into()),
         Err(e) => {
             tracing::warn!("Invalid timestamp in image: {:#}", e);
             None


### PR DESCRIPTION
These are massive overkill for what we need now, and in particular k8s-openapi contains huge amounts of generated code.

Reimplement the tiny subset of k8s metadata we need.