### PR TITLE
spec: Make status always required

### DIFF
--- a/ci/run-kola.sh
+++ b/ci/run-kola.sh
@@ -25,6 +25,15 @@ storage:
     - path: /etc/ostree/auth.json
       contents:
         local: auth.json
+systemd:
+  units:
+    - name: zincati.service
+      dropins:
+        - name: disabled.conf
+          contents: |
+            [Unit]
+            ConditionPathExists=/enoent
+
 EOF
     butane -d . < pull-secret.bu > pull-secret.ign
     kola_args+=("--append-ignition" "pull-secret.ign")

--- a/lib/src/privtests.rs
+++ b/lib/src/privtests.rs
@@ -103,8 +103,7 @@ pub(crate) fn impl_run_container() -> Result<()> {
     assert!(ostree_ext::container_utils::is_ostree_container()?);
     let sh = Shell::new()?;
     let host: Host = serde_yaml::from_str(&cmd!(sh, "bootc status").read()?)?;
-    let status = host.status.unwrap();
-    assert!(status.is_container);
+    assert!(host.status.is_container);
     for c in ["upgrade", "update"] {
         let o = Command::new("bootc").arg(c).output()?;
         let st = o.status;

--- a/lib/src/spec.rs
+++ b/lib/src/spec.rs
@@ -19,7 +19,8 @@ pub struct Host {
     #[serde(default)]
     pub spec: HostSpec,
     /// The status
-    pub status: Option<HostStatus>,
+    #[serde(default)]
+    pub status: HostStatus,
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq, Eq)]
@@ -121,7 +122,7 @@ impl Host {
                 metadata,
             },
             spec,
-            status: None,
+            status: Default::default(),
         }
     }
 }


### PR DESCRIPTION
This avoids unnecessary digging through an `Option`, particularly some `unwrap()` usage.