### PR TITLE
install: Add more image metadata to aleph

### DIFF
--- a/lib/src/status.rs
+++ b/lib/src/status.rs
@@ -88,7 +88,7 @@ pub(crate) struct Deployments {
     pub(crate) other: VecDeque<ostree::Deployment>,
 }
 
-fn try_deserialize_timestamp(t: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+pub(crate) fn try_deserialize_timestamp(t: &str) -> Option<chrono::DateTime<chrono::Utc>> {
     match chrono::DateTime::parse_from_rfc3339(t).context("Parsing timestamp") {
         Ok(t) => Some(t.into()),
         Err(e) => {


### PR DESCRIPTION
Motivated by https://issues.redhat.com/browse/COS-2526

It's quite possible that the image sha will have been GCd, but the version number and timestamp inside the image (not just the file timestamp) are probably sufficient for general reference.