### PR TITLE
tree: Pass through `cargo clippy --fix`

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -441,7 +441,7 @@ async fn edit(opts: EditOpts) -> Result<()> {
         anyhow::bail!("No changes in current host spec");
     }
     let new_spec = RequiredHostSpec::from_spec(&new_host.spec)?;
-    let fetched = pull(repo, &new_spec.image, opts.quiet).await?;
+    let fetched = pull(repo, new_spec.image, opts.quiet).await?;
 
     // TODO gc old layers here
 

--- a/lib/src/deploy.rs
+++ b/lib/src/deploy.rs
@@ -128,7 +128,7 @@ pub(crate) async fn stage(
         sysroot,
         merge_deployment.as_ref(),
         stateroot,
-        &image,
+        image,
         &origin,
     )
     .await?;

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -1091,10 +1091,10 @@ pub(crate) async fn install_to_filesystem(opts: InstallToFilesystemOpts) -> Resu
     let rootarg = format!("root={root_mount_spec}");
     let boot = if let Some(spec) = fsopts.boot_mount_spec {
         Some(MountSpec::new(&spec, "/boot"))
-    } else if let Some(boot_uuid) = boot_uuid.as_deref() {
-        Some(MountSpec::new_uuid_src(&boot_uuid, "/boot"))
     } else {
-        None
+        boot_uuid
+            .as_deref()
+            .map(|boot_uuid| MountSpec::new_uuid_src(boot_uuid, "/boot"))
     };
     // By default, we inject a boot= karg because things like FIPS compliance currently
     // require checking in the initramfs.

--- a/lib/src/install/baseline.rs
+++ b/lib/src/install/baseline.rs
@@ -372,7 +372,7 @@ pub(crate) fn install_create_rootfs(
             .run()?;
         let efifs_path = bootfs.join(crate::bootloader::EFI_DIR);
         std::fs::create_dir(&efifs_path).context("Creating efi dir")?;
-        mount::mount(&espdev, &efifs_path)?;
+        mount::mount(espdev, &efifs_path)?;
     }
 
     let luks_device = match opts.block_setup {


### PR DESCRIPTION
All the clippy warnings were `--fix`able.