### PR TITLE
make validate: add new target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,11 @@ test-bin-archive: all-test
 install-kola-tests:
 	install -D -t $(DESTDIR)$(prefix)/lib/coreos-assembler/tests/kola/bootc tests/kolainst/*
 
+validate:
+	cargo fmt
+	cargo clippy
+.PHONY: validate
+
 vendor:
 	cargo xtask $@
 .PHONY: vendor


### PR DESCRIPTION
Add a `make validate` target to run cargo-fmt and cargo-clippy. My muscle memory from other containers/ projects is strong where I am used to run `make validate` before committing/pushing changes.