### PR TITLE
cli: Correctly no-op unchanged updates

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -342,8 +342,14 @@ async fn upgrade(opts: UpgradeOpts) -> Result<()> {
         let staged_unchanged = staged_digest
             .map(|d| d == fetched_digest)
             .unwrap_or_default();
+        let booted_unchanged = booted_image
+            .as_ref()
+            .map(|img| img.manifest_digest.as_str() == fetched_digest)
+            .unwrap_or_default();
         if staged_unchanged {
             println!("Staged update present, not changed.");
+        } else if booted_unchanged {
+            println!("No update available.")
         } else {
             let osname = booted_deployment.osname();
             crate::deploy::stage(sysroot, &osname, &fetched, &spec).await?;

--- a/tests/kolainst/basic
+++ b/tests/kolainst/basic
@@ -19,6 +19,11 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     echo "booted into $image"
     echo "ok status test"
 
+    test "null" = $(jq '.status.staged' < status.json)
+    # Should be a no-op
+    bootc update
+    test "null" = $(jq '.status.staged' < status.json)
+
     test '!' -w /usr
     bootc usroverlay
     test -w /usr


### PR DESCRIPTION
Regression from previous rework around staged diffs; we were incorectly re-staging the same thing.