### PR TITLE
  systemd: New bootc-fetch-apply-updates.{timer,service} 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,15 @@ all-test:
 install:
 	install -D -m 0755 -t $(DESTDIR)$(prefix)/bin target/release/bootc
 	install -d $(DESTDIR)$(prefix)/lib/bootc/install
+	# Support installing pre-generated man pages shipped in source tarball, to avoid
+	# a dependency on pandoc downstream
+	if test -d man; then install -D -m 0644 -t $(DESTDIR)$(prefix)/share/man/man5 man/*.5; fi
 	if test -d man; then install -D -m 0644 -t $(DESTDIR)$(prefix)/share/man/man8 man/*.8; fi
+
+# These are not installed by default; one recommendation is to put them in a separate
+# sub-package or sub-component.
+install-systemd-auto:
+	install -D -m 0644 -t $(DESTDIR)/$(prefix)/lib/systemd/system systemd/*.service systemd/*.timer
 
 bin-archive: all
 	$(MAKE) install DESTDIR=tmp-install && tar --zstd -C tmp-install -cf target/bootc.tar.zst . && rm tmp-install -rf

--- a/manpages-md-extra/bootc-fetch-apply-updates.service.md
+++ b/manpages-md-extra/bootc-fetch-apply-updates.service.md
@@ -1,0 +1,27 @@
+# NAME
+
+bootc-fetch-apply-updates.service
+
+# DESCRIPTION
+
+This service causes `bootc` to perform the following steps:
+
+- Check the source registry for an updated container image
+- If one is found, download it
+- Reboot
+
+This service also comes with a companion `bootc-fetch-apply-updates.timer`
+systemd unit.  The current default systemd timer shipped in the upstream
+project is enabled for daily updates.
+
+However, it is fully expected that different operating systems
+and distributions choose different defaults.
+
+## Customizing updates
+
+Note that all three of these steps can be decoupled; they
+are:
+
+- `bootc upgrade --check`
+- `bootc upgrade`
+- `bootc upgrade --apply`

--- a/systemd/bootc-fetch-apply-updates.service
+++ b/systemd/bootc-fetch-apply-updates.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Apply bootc updates
+Documentation=man:bootc(8)
+ConditionPathExists=/run/ostree-booted
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/bootc update --apply --quiet

--- a/systemd/bootc-fetch-apply-updates.timer
+++ b/systemd/bootc-fetch-apply-updates.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Apply bootc updates
+Documentation=man:bootc(8)
+ConditionPathExists=/run/ostree-booted
+
+[Timer]
+OnBootSec=1h
+# This time is relatively arbitrary and obviously expected to be overridden/changed
+OnUnitInactiveSec=8h
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Let's ship a baseline systemd unit that can be enabled for automatic updates.