### PR TITLE
install: Drop `--net=none` suggestion

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -47,7 +47,7 @@ other options.
 Here's an example:
 
 ```
-$ podman run --privileged --pid=host --net=none --security-opt label=type:unconfined_t <image> bootc install --target-no-signature-verification /path/to/disk
+$ podman run --privileged --pid=host --security-opt label=type:unconfined_t <image> bootc install --target-no-signature-verification /path/to/disk
 ```
 
 Note that while `--privileged` is used, this command will not
@@ -56,11 +56,6 @@ perform any destructive action on the host system.
 The `--pid=host --security-opt label=type:unconfined_t` today
 make it more convenient for bootc to perform some privileged
 operations; in the future these requirement may be dropped.
-
-The `--net=none` argument is just to emphasize the fact that
-an installation by default is not fetching anything else external
-from the network - the content to be installed
-*is the running container image content*.
 
 ### Operating system install configuration required
 
@@ -193,7 +188,7 @@ support the root storage setup already initialized.
 The core command should look like this:
 
 ```
-$ podman run --privileged -v /:/target --pid=host --net=none --security-opt label=type:install_t \
+$ podman run --privileged -v /:/target --pid=host --security-opt label=type:install_t \
   <image> \
   bootc install-to-filesystem --replace=alongside /target
 ```

--- a/lib/src/privtests.rs
+++ b/lib/src/privtests.rs
@@ -152,7 +152,7 @@ fn test_install_filesystem(image: &str, blockdev: &Utf8Path) -> Result<()> {
     let mountpoint: &Utf8Path = mountpoint_dir.path().try_into().unwrap();
 
     // And run the install
-    cmd!(sh, "podman run --rm --privileged --pid=host --net=none --env=RUST_LOG -v /usr/bin/bootc:/usr/bin/bootc -v {mountpoint}:/target-root {image} bootc install-to-filesystem /target-root").run()?;
+    cmd!(sh, "podman run --rm --privileged --pid=host --env=RUST_LOG -v /usr/bin/bootc:/usr/bin/bootc -v {mountpoint}:/target-root {image} bootc install-to-filesystem /target-root").run()?;
 
     cmd!(sh, "umount -R {mountpoint}").run()?;
 

--- a/tests/kolainst/install
+++ b/tests/kolainst/install
@@ -19,7 +19,7 @@ cd $(mktemp -d)
 
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "")
-    podman run --rm -ti --privileged --pid=host --net=none -v /usr/bin/bootc:/usr/bin/bootc ${IMAGE} bootc install --karg=foo=bar ${DEV}
+    podman run --rm -ti --privileged --pid=host -v /usr/bin/bootc:/usr/bin/bootc ${IMAGE} bootc install --karg=foo=bar ${DEV}
     # In theory we could e.g. wipe the bootloader setup on the primary disk, then reboot;
     # but for now let's just sanity test that the install command executes.
     lsblk ${DEV}


### PR DESCRIPTION
While it's actually nice to show that the container can just install itself, I'm trying to reduce the command line length of the invocation in the interest of simplicity.

There's a minor cost here as it means we'll get a default bridge network, but that hardly matters.  Anyone who wants to avoid it can just specify `--net=none` on their own.

However this said, I think longer term we do want to support networking at install time in order to do things like fetch configmaps, so dropping this is prep for that too.