### PR TITLE
install: Verify target image fetch by default

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -59,6 +59,26 @@ The `--pid=host --security-opt label=type:unconfined_t` today
 make it more convenient for bootc to perform some privileged
 operations; in the future these requirement may be dropped.
 
+### "day 2" updates, security and fetch configuration
+
+Note that by default the `bootc install` path will find the pull specification used
+for the `podman run` invocation and use it to set up "day 2" OS updates that `bootc update`
+will use.
+
+For example, if you invoke `podman run --privileged ... quay.io/examplecorp/exampleos:latest bootc install ...`
+then the installed operating system will fetch updates from `quay.io/examplecorp/exampleos:latest`.
+This can be overridden via `--target_imgref`; this is handy in cases like performing
+installation in a manufacturing environment from a mirrored registry.
+
+By default, the installation process will verify that the container (representing the target OS)
+can fetch its own updates.  A common cause of failure here is not changing the security settings
+in `/etc/containers/policy.json` in the target OS to verify signatures.
+
+If you are pushing an unsigned image, you must specify `bootc install --target-no-signature-verification`.
+
+Additionally note that to perform an install from an authenticated registry, you must also embed
+the pull secret into the image to pass this check.  If you are fetching
+
 ### Operating system install configuration required
 
 The container image must define its default install configuration.  For example,

--- a/lib/src/privtests.rs
+++ b/lib/src/privtests.rs
@@ -152,7 +152,7 @@ fn test_install_filesystem(image: &str, blockdev: &Utf8Path) -> Result<()> {
     let mountpoint: &Utf8Path = mountpoint_dir.path().try_into().unwrap();
 
     // And run the install
-    cmd!(sh, "podman run --rm --privileged --pid=host --env=RUST_LOG -v /usr/bin/bootc:/usr/bin/bootc -v {mountpoint}:/target-root {image} bootc install-to-filesystem /target-root").run()?;
+    cmd!(sh, "podman run --rm --privileged --pid=host --env=RUST_LOG -v /usr/bin/bootc:/usr/bin/bootc -v {mountpoint}:/target-root {image} bootc install-to-filesystem --target-no-signature-verification /target-root").run()?;
 
     cmd!(sh, "umount -R {mountpoint}").run()?;
 

--- a/tests/kolainst/install
+++ b/tests/kolainst/install
@@ -19,7 +19,7 @@ cd $(mktemp -d)
 
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "")
-    podman run --rm -ti --privileged --pid=host -v /usr/bin/bootc:/usr/bin/bootc ${IMAGE} bootc install --karg=foo=bar ${DEV}
+    podman run --rm -ti --privileged --pid=host -v /usr/bin/bootc:/usr/bin/bootc ${IMAGE} bootc install --target-no-signature-verification --karg=foo=bar ${DEV}
     # In theory we could e.g. wipe the bootloader setup on the primary disk, then reboot;
     # but for now let's just sanity test that the install command executes.
     lsblk ${DEV}


### PR DESCRIPTION
install: Compute target image reference upfront

Prep for verifying it before we do an install.

Signed-off-by: Colin Walters <walters@verbum.org>

---

install: Verify target image fetch by default

Now that we've dropped the `--net=none` by default, let's
avoid two major footguns by verifying the target image specification
by default.

- Forgetting to use `--target-no-signature-verification` (most people are going to need this in demos right now)
- When the target OS requires an authenticated pull, but one didn't embed the pull secret in the target OS

Signed-off-by: Colin Walters <walters@verbum.org>

---

