### PR TITLE
install: Enable bootprefix by default

### DIFF
--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -466,6 +466,9 @@ async fn initialize_ostree_root_from_self(
     };
     for (k, v) in [
         ("sysroot.bootloader", bootloader),
+        // Always flip this one on because we need to support alongside installs
+        // to systems without a separate boot partition.
+        ("sysroot.bootprefix", "true"),
         ("sysroot.readonly", "true"),
     ] {
         Task::new("Configuring ostree repo", "ostree")


### PR DESCRIPTION
This is the last bit necessary to enable installations to systems without a separate `/boot` partition (as is true in the default RHEL 9 AMIs).

I was too chicken to enable it by default in ostree long ago; and now here we are.  Should definitely enable it in ostree, but let's do it here now.