### PR TITLE
docs: update required dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,17 +2,19 @@
 
 In order to build `bootc` you will need the following dependencies.
 
-Fedora: 
-```
-sudo dnf install ostree-libs ostree-devel
+Fedora:
+
+```bash
+sudo dnf install clippy openssl-devel ostree-devel ostree-libs rustfmt
 ```
 
 # Pre flight checks
 
-Makes sure you commented your code additions, then run 
-```
+Make sure you commented your code additions, then run
+
+```bash
 cargo fmt
 cargo clippy
 ```
-Make sure to apply any relevant suggestions. 
 
+Make sure to apply any relevant suggestions.


### PR DESCRIPTION
In a fresh Fedora 39 container, I had to install the updated list of dependencies to successfully run:

- cargo fmt
- cargo clippy
- cargo build --release