### PR TITLE
lib: apply clippy fix for needless borrowing

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -447,7 +447,7 @@ async fn edit(opts: EditOpts) -> Result<()> {
     let (booted_deployment, _deployments, host) =
         crate::status::get_status_require_booted(sysroot)?;
     let new_host: Host = if let Some(filename) = opts.filename {
-        let mut r = std::io::BufReader::new(std::fs::File::open(&filename)?);
+        let mut r = std::io::BufReader::new(std::fs::File::open(filename)?);
         serde_yaml::from_reader(&mut r)?
     } else {
         let tmpf = tempfile::NamedTempFile::new()?;

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -791,7 +791,7 @@ async fn verify_target_fetch(imgref: &ostree_container::OstreeImageReference) ->
 
     tracing::trace!("Verifying fetch for {imgref}");
     let mut imp =
-        ostree_container::store::ImageImporter::new(&tmprepo, imgref, Default::default()).await?;
+        ostree_container::store::ImageImporter::new(tmprepo, imgref, Default::default()).await?;
     use ostree_container::store::PrepareResult;
     let prep = match imp.prepare().await? {
         // SAFETY: It's impossible that the image was already fetched into this newly created temporary repository


### PR DESCRIPTION
See: https://rust-lang.github.io/rust-clippy/master/index.html#/needless_borrow

Applied `cargo clippy --fix --lib -p bootc-lib`