### PR TITLE
containerenv: small error message fix

### DIFF
--- a/lib/src/containerenv.rs
+++ b/lib/src/containerenv.rs
@@ -7,6 +7,7 @@ use cap_std_ext::cap_std::fs::Dir;
 use cap_std_ext::prelude::CapStdExtDirExt;
 use fn_error_context::context;
 
+/// Path is relative to container rootfs (assumed to be /)
 const PATH: &str = "run/.containerenv";
 
 #[derive(Debug, Default)]
@@ -25,7 +26,9 @@ pub(crate) fn get_container_execution_info(rootfs: &Dir) -> Result<ContainerExec
     let f = match rootfs.open_optional(PATH)? {
         Some(f) => BufReader::new(f),
         None => {
-            anyhow::bail!("This command must be executed inside a podman container (missing {PATH}")
+            anyhow::bail!(
+                "This command must be executed inside a podman container (missing /{PATH})"
+            )
         }
     };
     let mut r = ContainerExecutionInfo::default();


### PR DESCRIPTION
This tweaks the error message when `.containerenv` cannot be found so that a fully-qualified path is included in the error.

Previously, the error message would just show `run/.containerenv` as the path to the file, which is not entirely clear.

I tried to change the `const PATH` to be an absolute path, but doing so breaks the ability for `open_optional()` to open the file successfully; returns an error `a path led outside of the filesystem`.