### PR TITLE
install: Add `kargs` to installation config

### DIFF
--- a/ci/Dockerfile.fcos
+++ b/ci/Dockerfile.fcos
@@ -7,4 +7,5 @@ RUN make test-bin-archive
 
 FROM quay.io/fedora/fedora-coreos:testing-devel
 COPY --from=builder /src/target/bootc.tar.zst /tmp
+COPY ci/usr usr
 RUN tar -xvf /tmp/bootc.tar.zst && ostree container commit 

--- a/ci/usr/lib/bootc/install/50-test-kargs.toml
+++ b/ci/usr/lib/bootc/install/50-test-kargs.toml
@@ -1,0 +1,2 @@
+[install]
+kargs = ["localtestkarg=somevalue", "otherlocalkarg=42"]

--- a/docs/install.md
+++ b/docs/install.md
@@ -96,20 +96,31 @@ in that case you will need to specify `--skip-fetch-check`.
 
 ### Operating system install configuration required
 
-The container image **MUST** define its default install configuration.  For example,
-create `/usr/lib/bootc/install/00-exampleos.toml` with the contents:
+The container image **MUST** define its default install configuration.  A key choice
+that bootc by default leaves up to the operating system image is the root filesystem
+type.
+
+To enable `bootc install` as part of your OS/distribution base image,
+create a file named `/usr/lib/bootc/install/00-<osname>.toml` with the contents of the form:
 
 ```toml
 [install]
 root-fs-type = "xfs"
 ```
 
-At the current time, `root-fs-type` is the only available configuration option, and it **MUST** be set.
+The `root-fs-type` value **MUST** be set.
 
 Configuration files found in this directory will be merged, with higher alphanumeric values
 taking precedence.  If for example you are building a derived container image from the above OS,
 you could create a `50-myos.toml`  that sets `root-fs-type = "btrfs"` which will override the
 prior setting.
+
+Other available options, also under the `[install]` section:
+
+`kargs`: This allows setting kernel arguments which apply only at the time of `bootc install`.
+This option is particularly useful when creating derived/layered images; for example, a cloud
+image may want to have its default `console=` set, in contrast with a default base image.
+The values in this field are space separated.
 
 ## Installing an "unconfigured" image
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -34,6 +34,7 @@ regex = "1.7.1"
 rustix = { "version" = "0.38", features = ["thread", "fs", "system", "process"] }
 schemars = { version = "0.8.6", features = ["chrono"] }
 serde = { features = ["derive"], version = "1.0.125" }
+serde_ignored = "0.1.9"
 serde_json = "1.0.64"
 serde_yaml = "0.9.17"
 serde_with = ">= 1.9.4, < 2"

--- a/lib/src/install/baseline.rs
+++ b/lib/src/install/baseline.rs
@@ -350,6 +350,14 @@ pub(crate) fn install_create_rootfs(
         .into_iter()
         .flatten()
         .chain([rootarg, RW_KARG.to_string(), bootarg].into_iter())
+        .chain(
+            state
+                .install_config
+                .kargs
+                .iter()
+                .flatten()
+                .map(ToOwned::to_owned),
+        )
         .collect::<Vec<_>>();
 
     mount::mount(&rootdev, &rootfs)?;

--- a/tests/kolainst/install
+++ b/tests/kolainst/install
@@ -19,12 +19,24 @@ cd $(mktemp -d)
 
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "")
-    podman run --rm -ti --privileged --pid=host -v /usr/bin/bootc:/usr/bin/bootc ${IMAGE} bootc install --target-no-signature-verification --karg=foo=bar ${DEV}
+    mkdir -p ~/.config/containers
+    cp -a /etc/ostree/auth.json ~/.config/containers
+    mkdir -p usr/{lib,bin}
+    cp -a /usr/lib/bootc usr/lib
+    cp -a /usr/bin/bootc usr/bin
+    cat > Dockerfile << EOF
+    FROM ${IMAGE}
+    COPY usr usr
+EOF
+    podman build -t localhost/testimage .
+    podman run --rm -ti --privileged --pid=host --env RUST_LOG=error,bootc_lib::install=debug \
+      localhost/testimage bootc install --target-no-signature-verification --skip-fetch-check --karg=foo=bar ${DEV}
     # In theory we could e.g. wipe the bootloader setup on the primary disk, then reboot;
     # but for now let's just sanity test that the install command executes.
     lsblk ${DEV}
     mount /dev/vda3 /var/mnt
     grep foo=bar /var/mnt/loader/entries/*.conf
+    grep localtestkarg=somevalue /var/mnt/loader/entries/*.conf
     grep -Ee '^linux /boot/ostree' /var/mnt/loader/entries/*.conf
     umount /var/mnt
     echo "ok install"


### PR DESCRIPTION
We know we eventually want "day 2" management of kargs, but supporting "install time" kargs in a somewhat container-native way will let us more properly set up things like the `console=` karg only for cloud images for example.