### PR TITLE
docs: fix injecting root keys example

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -171,7 +171,7 @@ for keys in this location.
 FROM <image>
 RUN mkdir -p /usr/etc-system/ && \
     echo 'AuthorizedKeysFile /usr/etc-system/%u.keys' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
-    echo 'ssh-ed25519 AAAAC3Nza... root@example.com' > /usr/etc-system/root.keys && chmod 0600 /usr/etc-system/keys && \
+    echo 'ssh-ed25519 AAAAC3Nza... root@example.com' > /usr/etc-system/root.keys && chmod 0600 /usr/etc-system/root.keys && \
     ostree container commit
 ```
 


### PR DESCRIPTION
Fails with the following otherwise:

```
STEP 9/11: RUN mkdir -p /usr/etc-system/ &&     echo 'AuthorizedKeysFile /usr/etc-system/%u.keys' >> /etc/ssh/sshd_config.d/30-auth-system.conf &&     echo 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL7xFq1HtZKZiaD8MfkhNtn37m8GSc1W168NoSaT9RSf cardno:000F_C36A3FC0' > /usr/etc-system/root.keys && chmod 0600 /usr/etc-system/keys
chmod: cannot access '/usr/etc-system/keys': No such file or directory
Error: building at STEP "RUN mkdir -p /usr/etc-system/ &&     echo 'AuthorizedKeysFile /usr/etc-system/%u.keys' >> /etc/ssh/sshd_config.d/30-auth-system.conf &&     echo 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL7xFq1HtZKZiaD8MfkhNtn37m8GSc1W168NoSaT9RSf cardno:000F_C36A3FC0' > /usr/etc-system/root.keys && chmod 0600 /usr/etc-system/keys": while running runtime: exit status 1
```