### PR TITLE
lib: Track ostree-ext git

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -6,7 +6,10 @@ allow = ["Apache-2.0", "Apache-2.0 WITH LLVM-exception", "MIT", "BSD-3-Clause", 
 # We want to require FIPS validation downstream, so we use openssl
 name = "ring"
 
+
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-allow-git = []
+allow-git = [
+    "https://github.com/ostreedev/ostree-rs-ext"
+]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -15,7 +15,7 @@ anstream = "0.6.4"
 anstyle = "1.0.4"
 anyhow = "1.0"
 camino = { version = "1.0.4", features = ["serde1"] }
-ostree-ext = "0.12"
+ostree-ext = { version = "0.12", git = "https://github.com/ostreedev/ostree-rs-ext/"}
 chrono = { version = "0.4.23", features = ["serde"] }
 clap = { version= "4.2", features = ["derive"] }
 clap_mangen = { version = "0.2", optional = true }


### PR DESCRIPTION
This will help ensure we're testing what's there before release, in particular https://github.com/ostreedev/ostree-rs-ext/pull/569