### PR TITLE
install: Rename `install` -> `install to-disk`, peer with `to-filesystem`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
         run: |
           set -xeuo pipefail
           sudo podman run --rm -ti --privileged -v /:/target -v ./usr/bin/bootc:/usr/bin/bootc --pid=host --security-opt label=disable \
-            quay.io/centos-bootc/fedora-bootc-dev:eln bootc install-to-filesystem --target-no-signature-verification \
+            quay.io/centos-bootc/fedora-bootc-dev:eln bootc install to-filesystem --target-no-signature-verification \
             --karg=foo=bar --disable-selinux --replace=alongside /target
           ls -al /boot/loader/
           sudo grep foo=bar /boot/loader/entries/*.conf

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,10 +89,15 @@ First, build a derived container using any container build tooling.
 
 #### Using `bootc install`
 
-The `bootc install` command will write the current container to a disk, and set it up for booting.
+The `bootc install` command has two high level sub-commands; `to-disk` and `to-filesystem`.
+
+The `bootc install to-disk` handles basically everything in taking the current container
+and writing it to a disk, and set it up for booting and future in-place upgrades.
+
 In brief, the idea is that every container image shipping `bootc` also comes with a simple
-installer that can set a system up to boot from it.  Crucially, if you create a 
-*derivative* container image from a stock OS container image, it also automatically supports `bootc install`.
+installer that can set a system up to boot from it.  Crucially, if you create a
+*derivative* container image from a stock OS container image, it also automatically
+supports `bootc install`.
 
 For more information, please see [install.md](install.md).
 

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -2,7 +2,7 @@
 //!
 //! This module supports installing a bootc-compatible image to
 //! a block device directly via the `install` verb, or to an externally
-//! set up filesystem via `install-to-filesystem`.
+//! set up filesystem via `install to-filesystem`.
 
 // This sub-module is the "basic" installer that handles creating basic block device
 // and filesystem setup.
@@ -118,7 +118,7 @@ pub(crate) struct InstallConfigOpts {
 
 /// Perform an installation to a block device.
 #[derive(Debug, Clone, clap::Parser, Serialize, Deserialize)]
-pub(crate) struct InstallOpts {
+pub(crate) struct InstallToDiskOpts {
     #[clap(flatten)]
     #[serde(flatten)]
     pub(crate) block_opts: InstallBlockDeviceOpts,
@@ -1021,8 +1021,8 @@ fn installation_complete() {
     println!("Installation complete!");
 }
 
-/// Implementation of the `bootc install` CLI command.
-pub(crate) async fn install(opts: InstallOpts) -> Result<()> {
+/// Implementation of the `bootc install to-disk` CLI command.
+pub(crate) async fn install_to_disk(opts: InstallToDiskOpts) -> Result<()> {
     let block_opts = opts.block_opts;
     let state = prepare_install(opts.config_opts, opts.target_opts).await?;
 
@@ -1113,7 +1113,7 @@ fn clean_boot_directories(rootfs: &Dir) -> Result<()> {
     Ok(())
 }
 
-/// Implementation of the `bootc install-to-filsystem` CLI command.
+/// Implementation of the `bootc install to-filsystem` CLI command.
 pub(crate) async fn install_to_filesystem(opts: InstallToFilesystemOpts) -> Result<()> {
     // Gather global state, destructuring the provided options
     let state = prepare_install(opts.config_opts, opts.target_opts).await?;
@@ -1252,7 +1252,7 @@ pub(crate) async fn install_to_filesystem(opts: InstallToFilesystemOpts) -> Resu
 
 #[test]
 fn install_opts_serializable() {
-    let c: InstallOpts = serde_json::from_value(serde_json::json!({
+    let c: InstallToDiskOpts = serde_json::from_value(serde_json::json!({
         "device": "/dev/vda"
     }))
     .unwrap();

--- a/lib/src/install/baseline.rs
+++ b/lib/src/install/baseline.rs
@@ -3,7 +3,7 @@
 //! This module handles creation of simple root filesystem setups.  At the current time
 //! it's very simple - just a direct filesystem (e.g. xfs, ext4, btrfs etc.).  It is
 //! intended to add opinionated handling of TPM2-bound LUKS too.  But that's about it;
-//! other more complex flows should set things up externally and use `bootc install-to-filesystem`.
+//! other more complex flows should set things up externally and use `bootc install to-filesystem`.
 
 use std::borrow::Cow;
 use std::fmt::Display;

--- a/lib/src/privtests.rs
+++ b/lib/src/privtests.rs
@@ -152,7 +152,7 @@ fn test_install_filesystem(image: &str, blockdev: &Utf8Path) -> Result<()> {
     let mountpoint: &Utf8Path = mountpoint_dir.path().try_into().unwrap();
 
     // And run the install
-    cmd!(sh, "podman run --rm --privileged --pid=host --env=RUST_LOG -v /usr/bin/bootc:/usr/bin/bootc -v {mountpoint}:/target-root {image} bootc install-to-filesystem --target-no-signature-verification /target-root").run()?;
+    cmd!(sh, "podman run --rm --privileged --pid=host --env=RUST_LOG -v /usr/bin/bootc:/usr/bin/bootc -v {mountpoint}:/target-root {image} bootc install to-filesystem --target-no-signature-verification /target-root").run()?;
 
     cmd!(sh, "umount -R {mountpoint}").run()?;
 

--- a/tests/kolainst/install
+++ b/tests/kolainst/install
@@ -30,7 +30,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
 EOF
     podman build -t localhost/testimage .
     podman run --rm -ti --privileged --pid=host --env RUST_LOG=error,bootc_lib::install=debug \
-      localhost/testimage bootc install --target-no-signature-verification --skip-fetch-check --karg=foo=bar ${DEV}
+      localhost/testimage bootc install to-disk --target-no-signature-verification --skip-fetch-check --karg=foo=bar ${DEV}
     # In theory we could e.g. wipe the bootloader setup on the primary disk, then reboot;
     # but for now let's just sanity test that the install command executes.
     lsblk ${DEV}
@@ -41,7 +41,7 @@ EOF
     umount /var/mnt
     echo "ok install"
 
-    # Now test install-to-filesystem
+    # Now test install to-filesystem
     # Wipe the device
     ls ${DEV}* | tac | xargs wipefs -af
     # This prepares the device and also runs podman directliy


### PR DESCRIPTION
install: Rename `install` -> `install to-disk`, peer with `to-filesystem`

Take the current `install` verb and change it to be
`bootc install to-disk`, and then `install-to-filesystem` becomes
`bootc install to-filesystem` - they are obvious peers.

The main motivation here is that in the end many use cases will
want nontrivial filesystem customization, and while I like having
a fully opinionated builtin flow to write to a target disk,
we should really think of `to-filesystem` as a fully equal peer
of `to-disk`.

Signed-off-by: Colin Walters <walters@verbum.org>

---

install-to-disk: Verify target is a block device

I saw someone get confused and think `bootc install` could work
on a filesystem.

Signed-off-by: Colin Walters <walters@verbum.org>

---

install-to-filesystem: Verify target is a dir+mountpoint

Similarly to previous patch for `install to-disk`, verify
that the target is a directory *and* that it's a mountpoint (we
can't sanely support installing to a subdirectory of a filesystem).

Signed-off-by: Colin Walters <walters@verbum.org>

---

