### PR TITLE
install: Add tracing and error context around re-exec

### DIFF
--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -675,16 +675,17 @@ pub(crate) fn exec_in_host_mountns(args: &[std::ffi::OsString]) -> Result<()> {
     let (cmd, args) = args[1..]
         .split_first()
         .ok_or_else(|| anyhow::anyhow!("Missing command"))?;
+    tracing::trace!("{cmd:?} {args:?}");
     let pid1mountns = std::fs::File::open("/proc/1/ns/mnt")?;
     nix::sched::setns(pid1mountns.as_fd(), nix::sched::CloneFlags::CLONE_NEWNS).context("setns")?;
-    rustix::process::chdir("/")?;
+    rustix::process::chdir("/").context("chdir")?;
     // Work around supermin doing chroot() and not pivot_root
     // https://github.com/libguestfs/supermin/blob/5230e2c3cd07e82bd6431e871e239f7056bf25ad/init/init.c#L288
     if !Utf8Path::new("/usr").try_exists()? && Utf8Path::new("/root/usr").try_exists()? {
         tracing::debug!("Using supermin workaround");
-        rustix::process::chroot("/root")?;
+        rustix::process::chroot("/root").context("chroot")?;
     }
-    Err(Command::new(cmd).args(args).exec())?
+    Err(Command::new(cmd).args(args).exec()).context("exec")?
 }
 
 #[context("Querying skopeo version")]


### PR DESCRIPTION
I hit a bug here and the error context and debug tracing would have been helpful.