### PR TITLE
Add a helper for generating sigpolicy

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -9,7 +9,6 @@ use fn_error_context::context;
 use ostree::gio;
 use ostree_container::store::PrepareResult;
 use ostree_ext::container as ostree_container;
-use ostree_ext::container::SignatureSource;
 use ostree_ext::keyfileext::KeyFileExt;
 use ostree_ext::ostree;
 use std::ffi::OsString;
@@ -20,6 +19,7 @@ use std::process::Command;
 use crate::deploy::RequiredHostSpec;
 use crate::spec::Host;
 use crate::spec::ImageReference;
+use crate::utils::sigpolicy_from_opts;
 
 /// Perform an upgrade operation
 #[derive(Debug, Parser)]
@@ -362,13 +362,10 @@ async fn switch(opts: SwitchOpts) -> Result<()> {
         transport,
         name: opts.target.to_string(),
     };
-    let sigverify = if opts.no_signature_verification {
-        SignatureSource::ContainerPolicyAllowInsecure
-    } else if let Some(remote) = opts.ostree_remote.as_ref() {
-        SignatureSource::OstreeRemote(remote.to_string())
-    } else {
-        SignatureSource::ContainerPolicy
-    };
+    let sigverify = sigpolicy_from_opts(
+        opts.no_signature_verification,
+        opts.ostree_remote.as_deref(),
+    );
     let target = ostree_container::OstreeImageReference { sigverify, imgref };
     let target = ImageReference::from(target);
 

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -32,7 +32,6 @@ use rustix::fs::MetadataExt;
 use fn_error_context::context;
 use ostree::gio;
 use ostree_ext::container as ostree_container;
-use ostree_ext::container::SignatureSource;
 use ostree_ext::ostree;
 use ostree_ext::prelude::Cast;
 use serde::{Deserialize, Serialize};
@@ -40,6 +39,7 @@ use serde::{Deserialize, Serialize};
 use self::baseline::InstallBlockDeviceOpts;
 use crate::containerenv::ContainerExecutionInfo;
 use crate::task::Task;
+use crate::utils::sigpolicy_from_opts;
 
 /// The default "stateroot" or "osname"; see https://github.com/ostreedev/ostree/issues/2794
 const STATEROOT_DEFAULT: &str = "default";
@@ -916,13 +916,10 @@ async fn prepare_install(
 
     // Parse the target CLI image reference options and create the *target* image
     // reference, which defaults to pulling from a registry.
-    let target_sigverify = if target_opts.target_no_signature_verification {
-        SignatureSource::ContainerPolicyAllowInsecure
-    } else if let Some(remote) = target_opts.target_ostree_remote.as_deref() {
-        SignatureSource::OstreeRemote(remote.to_string())
-    } else {
-        SignatureSource::ContainerPolicy
-    };
+    let target_sigverify = sigpolicy_from_opts(
+        target_opts.target_no_signature_verification,
+        target_opts.target_ostree_remote.as_deref(),
+    );
     let target_imgname = target_opts
         .target_imgref
         .as_deref()


### PR DESCRIPTION
Prep for further refactoring, targeting
https://github.com/containers/bootc/issues/218
This will help us find the places we're synthesizing a policy.

No functional changes intended.