### PR TITLE
Use `Task` generally over `Command`

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -19,6 +19,7 @@ mod lsm;
 mod reboot;
 mod reexec;
 mod status;
+mod task;
 mod utils;
 
 #[cfg(feature = "internal-testing-api")]
@@ -38,8 +39,6 @@ pub(crate) mod mount;
 #[cfg(feature = "install")]
 mod podman;
 pub mod spec;
-#[cfg(feature = "install")]
-mod task;
 
 #[cfg(feature = "docgen")]
 mod docgen;

--- a/lib/src/reboot.rs
+++ b/lib/src/reboot.rs
@@ -1,9 +1,10 @@
 //! Handling of system restarts/reboot
 
 use std::io::Write;
-use std::process::Command;
 
 use fn_error_context::context;
+
+use crate::task::Task;
 
 /// Initiate a system reboot.
 /// This function will only return in case of error.
@@ -12,10 +13,7 @@ pub(crate) fn reboot() -> anyhow::Result<()> {
     // Flush output streams
     let _ = std::io::stdout().flush();
     let _ = std::io::stderr().flush();
-    let st = Command::new("reboot").status()?;
-    if !st.success() {
-        anyhow::bail!("Failed to reboot: {st:?}");
-    }
+    Task::new("Rebooting system", "reboot").run()?;
     tracing::debug!("Initiated reboot, sleeping forever...");
     loop {
         std::thread::park();

--- a/lib/src/task.rs
+++ b/lib/src/task.rs
@@ -21,6 +21,13 @@ impl Task {
         Self::new_cmd(description, Command::new(exe.as_ref()))
     }
 
+    /// This API can be used in place of Command::new() generally and just adds error
+    /// checking on top.
+    pub(crate) fn new_quiet(exe: impl AsRef<str>) -> Self {
+        let exe = exe.as_ref();
+        Self::new(exe, exe).quiet()
+    }
+
     /// Set the working directory for this task.
     pub(crate) fn cwd(mut self, dir: &Dir) -> Result<Self> {
         self.cmd.cwd_dir(dir.try_clone()?);
@@ -52,6 +59,11 @@ impl Task {
 
     pub(crate) fn args<S: AsRef<OsStr>>(mut self, args: impl IntoIterator<Item = S>) -> Self {
         self.cmd.args(args);
+        self
+    }
+
+    pub(crate) fn arg<S: AsRef<OsStr>>(mut self, arg: S) -> Self {
+        self.cmd.args([arg]);
         self
     }
 


### PR DESCRIPTION
Especially in places where we call `.output()`, what we generally always want is to get stdout, but keep stderr going to the parent process stderr.  The `Command` API doesn't make this obvious to do, and worse forces every caller to manually check the exit status.

The `Task` API fixes both of these.

(Now, the Task API also defaults to printing a description,
 which we need suppress in many cases with `.quiet()`)