### PR TITLE
status: fix warning for unused doc comment

### DIFF
--- a/lib/src/status.rs
+++ b/lib/src/status.rs
@@ -64,7 +64,7 @@ impl From<ImageReference> for OstreeImageReference {
         Self {
             sigverify: img.signature.into(),
             imgref: ostree_container::ImageReference {
-                /// SAFETY: We validated the schema in kube-rs
+                // SAFETY: We validated the schema in kube-rs
                 transport: img.transport.as_str().try_into().unwrap(),
                 name: img.image,
             },


### PR DESCRIPTION
rustdoc does not generate documentation for expression fields