### PR TITLE
lib: `#![allow(clippy::needless_borrow)]`

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -12,6 +12,10 @@
 #![cfg_attr(feature = "dox", feature(doc_cfg))]
 #![deny(clippy::dbg_macro)]
 #![deny(clippy::todo)]
+// These two are in my experience the lints which are most likely
+// to trigger, and among the least valuable to fix.
+#![allow(clippy::needless_borrow)]
+#![allow(clippy::needless_borrows_for_generic_args)]
 
 pub mod cli;
 pub(crate) mod deploy;


### PR DESCRIPTION
In my experience this is far and away the clippy lint that is:

- Most common to trigger (especially when refactoring code)
- The least valuable to fix; there's no performance or correctness concerns really