### PR TITLE
cli: Explicitly require root privileges

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -245,6 +245,7 @@ pub(crate) fn require_root() -> Result<()> {
 /// A few process changes that need to be made for writing.
 #[context("Preparing for write")]
 pub(crate) async fn prepare_for_write() -> Result<()> {
+    crate::cli::require_root()?;
     if ostree_ext::container_utils::is_ostree_container()? {
         anyhow::bail!(
             "Detected container (ostree base); this command requires a booted host system."

--- a/lib/src/privtests.rs
+++ b/lib/src/privtests.rs
@@ -104,13 +104,24 @@ pub(crate) fn impl_run_container() -> Result<()> {
     let sh = Shell::new()?;
     let host: Host = serde_yaml::from_str(&cmd!(sh, "bootc status").read()?)?;
     assert!(host.status.is_container);
+    println!("ok status");
+
     for c in ["upgrade", "update"] {
         let o = Command::new("bootc").arg(c).output()?;
         let st = o.status;
         assert!(!st.success());
         let stderr = String::from_utf8(o.stderr)?;
-        assert!(stderr.contains("this command requires a booted host system"));
+        assert!(stderr.contains("This command requires full root privileges"));
     }
+    println!("ok upgrade/update are errors in container");
+
+    let o = Command::new("runuser")
+        .args(["-u", "bin", "bootc", "upgrade"])
+        .output()?;
+    assert!(!o.status.success());
+    let stderr = String::from_utf8(o.stderr)?;
+    assert!(stderr.contains("requires root privileges"));
+
     println!("ok container integration testing");
     Ok(())
 }

--- a/lib/src/status.rs
+++ b/lib/src/status.rs
@@ -261,6 +261,7 @@ pub(crate) fn get_status(
 }
 
 /// Implementation of the `bootc status` CLI command.
+#[context("Status")]
 pub(crate) async fn status(opts: super::cli::StatusOpts) -> Result<()> {
     let host = if ostree_ext::container_utils::is_ostree_container()? {
         let status = HostStatus {
@@ -271,6 +272,7 @@ pub(crate) async fn status(opts: super::cli::StatusOpts) -> Result<()> {
         r.status = status;
         r
     } else {
+        crate::cli::require_root()?;
         let sysroot = super::cli::get_locked_sysroot().await?;
         let booted_deployment = sysroot.booted_deployment();
         let (_deployments, host) = get_status(&sysroot, booted_deployment.as_ref())?;


### PR DESCRIPTION
We do this in the install flow, do it for CLI verbs like `status`, `update|upgrade` etc.