### PR TITLE
Add `HostType`, change `status` to always succeed

### DIFF
--- a/lib/src/privtests.rs
+++ b/lib/src/privtests.rs
@@ -6,6 +6,8 @@ use fn_error_context::context;
 use rustix::fd::AsFd;
 use xshell::{cmd, Shell};
 
+use crate::spec::HostType;
+
 use super::cli::TestingOpts;
 use super::spec::Host;
 
@@ -100,10 +102,9 @@ pub(crate) fn impl_run_host() -> Result<()> {
 
 #[context("Container tests")]
 pub(crate) fn impl_run_container() -> Result<()> {
-    assert!(ostree_ext::container_utils::is_ostree_container()?);
     let sh = Shell::new()?;
     let host: Host = serde_yaml::from_str(&cmd!(sh, "bootc status").read()?)?;
-    assert!(host.status.is_container);
+    assert!(matches!(host.status.ty, None));
     println!("ok status");
 
     for c in ["upgrade", "update"] {

--- a/tests/kolainst/basic
+++ b/tests/kolainst/basic
@@ -19,6 +19,13 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     echo "booted into $image"
     echo "ok status test"
 
+    host_ty=$(jq -r '.status.type' < status.json)
+    test "${host_ty}" = "bootcHost"
+    # Now fake things out with an empty /run
+    unshare -m /bin/sh -c 'mount -t tmpfs tmpfs /run; bootc status --json > status-no-run.json'
+    host_ty_norun=$(jq -r '.status.type' < status-no-run.json)
+    test "${host_ty_norun}" = "null"
+
     test "null" = $(jq '.status.staged' < status.json)
     # Should be a no-op
     bootc update


### PR DESCRIPTION
This depends on https://github.com/containers/bootc/pull/241

---

Add `HostType`, change `status` to always succeed

Closes: https://github.com/containers/bootc/discussions/242

Basically it'd be useful for folks to be able to run `bootc status --json`
and have that always work - if we're not on a bootc-booted system
then we just output null data.

Specifically we drop the `isContainer` field and replace it
with an optional non-exhaustive enumeration.  For anything we don't
know about we just output `None` i.e. `null` in JSON.

---

