### PR TITLE
spec: Add cached update metadata

### DIFF
--- a/lib/src/spec.rs
+++ b/lib/src/spec.rs
@@ -88,6 +88,8 @@ pub struct BootEntryOstree {
 pub struct BootEntry {
     /// The image reference
     pub image: Option<ImageStatus>,
+    /// The last fetched cached update metadata
+    pub cached_update: Option<ImageStatus>,
     /// Whether this boot entry is not compatible (has origin changes bootc does not understand)
     pub incompatible: bool,
     /// Whether this entry will be subject to garbage collection


### PR DESCRIPTION
In https://github.com/ostreedev/ostree-rs-ext/pull/537 we added a facility to cache metadata (manifest+config) for container image updates with an eye for use in rpm-ostree.

The `bootc update --check` code here in bootc was also updated to use it; but we didn't really expose it back in the status.

This closes the gap, just bridging the cached update metadata into status.  We want to do this as opposed to having `bootc update --check` grow its own API for example.