### PR TITLE
ci: Add GH labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,8 @@
+documentation:
+- changed-files:
+  - any-glob-to-any-file: 'docs/*'
+  - any-glob-to-any-file: 'manpages-md'
+  - README.md
+area/install:
+- changed-files:
+  - any-glob-to-any-file: 'lib/src/install*'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5


### PR DESCRIPTION
Because it's useful to track sub-components.