### PR TITLE
upgrade: fix --apply when the desired deployment is already staged

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -356,6 +356,10 @@ async fn upgrade(opts: UpgradeOpts) -> Result<()> {
             .unwrap_or_default();
         if staged_unchanged {
             println!("Staged update present, not changed.");
+
+            if opts.apply {
+                crate::reboot::reboot()?;
+            }
         } else if booted_unchanged {
             println!("No update available.")
         } else {


### PR DESCRIPTION
Previously, running:

`bootc update; bootc update --apply`

would result in the system not rebooting to apply the previously-staged deployment.

Closes: https://github.com/containers/bootc/issues/234