### PR TITLE
cli: Drop `upgrade --touch-if-changed`

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -28,9 +28,6 @@ pub(crate) struct UpgradeOpts {
     #[clap(long)]
     pub(crate) quiet: bool,
 
-    #[clap(long)]
-    pub(crate) touch_if_changed: Option<Utf8PathBuf>,
-
     /// Check if an update is available without applying it.
     ///
     /// This only downloads an updated manifest and image configuration (i.e. typically kilobyte-sized metadata)
@@ -376,9 +373,6 @@ async fn upgrade(opts: UpgradeOpts) -> Result<()> {
         }
     }
     if changed {
-        if let Some(path) = opts.touch_if_changed {
-            std::fs::write(&path, "").with_context(|| format!("Writing {path}"))?;
-        }
         if opts.apply {
             crate::reboot::reboot()?;
         }

--- a/manpages-md/bootc-upgrade.md
+++ b/manpages-md/bootc-upgrade.md
@@ -4,9 +4,8 @@ bootc-upgrade - Download and queue an updated container image to apply
 
 # SYNOPSIS
 
-**bootc-upgrade** \[**\--quiet**\] \[**\--touch-if-changed**\]
-\[**\--check**\] \[**\--apply**\] \[**-h**\|**\--help**\]
-\[**-V**\|**\--version**\]
+**bootc-upgrade** \[**\--quiet**\] \[**\--check**\] \[**\--apply**\]
+\[**-h**\|**\--help**\] \[**-V**\|**\--version**\]
 
 # DESCRIPTION
 
@@ -31,13 +30,12 @@ outside of a \`bootc upgrade \--apply\` do \*not\* upgrade.
 
 :   Dont display progress
 
-**\--touch-if-changed**=*TOUCH_IF_CHANGED*
-
-:   
-
 **\--check**
 
-:   Check if an update is available without applying it
+:   Check if an update is available without applying it.
+
+This only downloads an updated manifest and image configuration (i.e.
+typically kilobyte-sized metadata) as opposed to the image layers.
 
 **\--apply**
 


### PR DESCRIPTION
We expect people to be parsing our spec/status via e.g. JSON.