### PR TITLE
Switch inplace

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -386,14 +386,6 @@ async fn upgrade(opts: UpgradeOpts) -> Result<()> {
 /// Implementation of the `bootc switch` CLI command.
 #[context("Switching")]
 async fn switch(opts: SwitchOpts) -> Result<()> {
-    prepare_for_write().await?;
-    let cancellable = gio::Cancellable::NONE;
-
-    let sysroot = &get_locked_sysroot().await?;
-    let repo = &sysroot.repo();
-    let (booted_deployment, _deployments, host) =
-        crate::status::get_status_require_booted(sysroot)?;
-
     let transport = ostree_container::Transport::try_from(opts.transport.as_str())?;
     let imgref = ostree_container::ImageReference {
         transport,
@@ -405,6 +397,14 @@ async fn switch(opts: SwitchOpts) -> Result<()> {
     );
     let target = ostree_container::OstreeImageReference { sigverify, imgref };
     let target = ImageReference::from(target);
+
+    prepare_for_write().await?;
+    let cancellable = gio::Cancellable::NONE;
+
+    let sysroot = &get_locked_sysroot().await?;
+    let repo = &sysroot.repo();
+    let (booted_deployment, _deployments, host) =
+        crate::status::get_status_require_booted(sysroot)?;
 
     let new_spec = {
         let mut new_spec = host.spec.clone();

--- a/lib/src/spec.rs
+++ b/lib/src/spec.rs
@@ -1,5 +1,8 @@
 //! The definition for host system state.
 
+use std::fmt::Display;
+
+use ostree_ext::container::OstreeImageReference;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -149,8 +152,17 @@ impl Default for Host {
     }
 }
 
+impl Display for ImageReference {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let ostree_imgref = OstreeImageReference::from(self.clone());
+        ostree_imgref.fmt(f)
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
 
     #[test]
@@ -182,5 +194,14 @@ mod tests {
             host.spec.image.as_ref().unwrap().signature,
             Some(ImageSignature::OstreeRemote("fedora".into()))
         );
+    }
+
+    #[test]
+    fn test_display_imgref() {
+        let src = "ostree-unverified-registry:quay.io/example/foo:sometag";
+        let s = OstreeImageReference::from_str(src).unwrap();
+        let s = ImageReference::from(s);
+        let displayed = format!("{s}");
+        assert_eq!(displayed.as_str(), src);
     }
 }


### PR DESCRIPTION
switch: Move option processing earlier

This logic just converts the provided CLI options
into data structures, so it can come before we do
other things.

Prep for further work.

Signed-off-by: Colin Walters <walters@verbum.org>

---

spec: impl Display for ImageReference

I want this in a followup patch.

Signed-off-by: Colin Walters <walters@verbum.org>

---

switch: Add hidden `--mutate-in-place`

This is intended to be runnable in current Anaconda `%post`
to fix up its lack of support for `--target-imgref`.

Signed-off-by: Colin Walters <walters@verbum.org>

---

