### PR TITLE
install: Drop support for old skopeo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,22 +116,45 @@ jobs:
         run: sudo tar -C / -xvf bootc.tar.zst
       - name: Integration tests
         run: bootc internal-tests run-container-integration
-  privtest-alongside:
-    name: "Test install-alongside"
-    needs: build-fedora
+  build-skopeo-ubuntu:
+    name: "Build skopeo git main for ubuntu"
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: containers/skopeo
+          path: skopeo
+      - name: Install build deps
+        run: |
+          sudo sed -ie s,'# deb-src,deb-src,' /etc/apt/sources.list
+          sudo apt update
+          sudo apt build-dep -y skopeo
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '>=1.20'
+      - name: Build skopeo
+        run: cd skopeo && make bin/skopeo PREFIX=/usr
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: skopeo-ubuntu
+          path: skopeo/bin/skopeo
+  privtest-alongside:
+    name: "Test install-alongside"
+    needs: [build-fedora, build-skopeo-ubuntu]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download
+        uses: actions/download-artifact@v4
+        with:
+          name: skopeo-ubuntu
+      - run: chmod a+x skopeo && sudo mv skopeo /usr/bin
       - name: Download
         uses: actions/download-artifact@v3
         with:
           name: bootc.tar.zst
       - name: Install
         run: tar -xvf bootc.tar.zst
-      - name: Update host skopeo
-        run: |
-          echo 'deb http://cz.archive.ubuntu.com/ubuntu lunar main universe' | sudo tee -a /etc/apt/sources.list
-          sudo apt update
-          sudo apt upgrade skopeo
       - name: Integration tests
         run: |
           set -xeuo pipefail


### PR DESCRIPTION
Let's just hard require a skopeo that can fetch from `containers-storage`. Motivated by https://github.com/containers/bootc/pull/263 which was moving this code around.