### PR TITLE
Two systemd unit fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,6 @@ install:
 	# a dependency on pandoc downstream
 	if test -d man; then install -D -m 0644 -t $(DESTDIR)$(prefix)/share/man/man5 man/*.5; fi
 	if test -d man; then install -D -m 0644 -t $(DESTDIR)$(prefix)/share/man/man8 man/*.8; fi
-
-# These are not installed by default; one recommendation is to put them in a separate
-# sub-package or sub-component.
-install-systemd-auto:
 	install -D -m 0644 -t $(DESTDIR)/$(prefix)/lib/systemd/system systemd/*.service systemd/*.timer
 
 bin-archive: all

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,14 @@ install:
 	install -D -m 0755 -t $(DESTDIR)$(prefix)/bin target/release/bootc
 	install -d $(DESTDIR)$(prefix)/lib/bootc/install
 	# Support installing pre-generated man pages shipped in source tarball, to avoid
-	# a dependency on pandoc downstream
-	if test -d man; then install -D -m 0644 -t $(DESTDIR)$(prefix)/share/man/man5 man/*.5; fi
-	if test -d man; then install -D -m 0644 -t $(DESTDIR)$(prefix)/share/man/man8 man/*.8; fi
+	# a dependency on pandoc downstream.  But in local builds these end up in target/man,
+	# so we honor that too.
+	for d in man target/man; do \
+	  if test -d $$d; then \
+	    install -D -m 0644 -t $(DESTDIR)$(prefix)/share/man/man5 $$d/*.5; \
+	    install -D -m 0644 -t $(DESTDIR)$(prefix)/share/man/man8 $$d/*.8; \
+	  fi; \
+	  done
 	install -D -m 0644 -t $(DESTDIR)/$(prefix)/lib/systemd/system systemd/*.service systemd/*.timer
 
 bin-archive: all

--- a/manpages-md-extra/bootc-fetch-apply-updates.service.md
+++ b/manpages-md-extra/bootc-fetch-apply-updates.service.md
@@ -1,3 +1,5 @@
+% bootc-fetch-apply-updates(5)
+
 # NAME
 
 bootc-fetch-apply-updates.service
@@ -17,7 +19,7 @@ project is enabled for daily updates.
 However, it is fully expected that different operating systems
 and distributions choose different defaults.
 
-## Customizing updates
+# CUSTOMIZING UPDATES
 
 Note that all three of these steps can be decoupled; they
 are:
@@ -25,3 +27,7 @@ are:
 - `bootc upgrade --check`
 - `bootc upgrade`
 - `bootc upgrade --apply`
+
+# SEE ALSO
+
+**bootc(1)**

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -17,4 +17,5 @@ camino = "1.0"
 chrono = { version = "0.4.23", default_features = false, features = ["std"] }
 fn-error-context = "0.2.0"
 tempfile = "3.3"
+mandown = "0.1"
 xshell = { version = "0.2" }

--- a/xtask/src/xtask.rs
+++ b/xtask/src/xtask.rs
@@ -104,11 +104,12 @@ fn manpages(sh: &Shell) -> Result<()> {
             .file_stem()
             .and_then(|name| name.to_str())
             .ok_or_else(|| anyhow!("Expected filename in {srcpath:?}"))?;
-        cmd!(
-            sh,
-            "pandoc -s --from=markdown --to=man --output=target/man/{base_filename}.5 {srcpath}"
-        )
-        .run()?;
+        let src =
+            std::fs::read_to_string(&srcpath).with_context(|| format!("Reading {srcpath:?}"))?;
+        let section = 5;
+        let buf = mandown::convert(&src, base_filename, section);
+        let target = format!("target/man/{base_filename}.{section}");
+        std::fs::write(&target, buf).with_context(|| format!("Writing {target}"))?;
     }
     Ok(())
 }

--- a/xtask/src/xtask.rs
+++ b/xtask/src/xtask.rs
@@ -106,7 +106,7 @@ fn manpages(sh: &Shell) -> Result<()> {
             .ok_or_else(|| anyhow!("Expected filename in {srcpath:?}"))?;
         cmd!(
             sh,
-            "pandoc --from=markdown --to=man --output=target/man/{base_filename}.5 {srcpath}"
+            "pandoc -s --from=markdown --to=man --output=target/man/{base_filename}.5 {srcpath}"
         )
         .run()?;
     }


### PR DESCRIPTION
build: Install systemd units by default

I was being too chicken; there's no reason not to install our
systemd units by default.  They're not enabled by default,
but we do want to encourage their use.

---

Fix manpage for service

We need `-s` for the pandoc invocation to render this right.

---

