### PR TITLE
install: Add `print-configuration`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
     name: "Container testing"
     needs: build-fedora
     runs-on: ubuntu-latest
-    container: quay.io/fedora/fedora-coreos:testing-devel
+    container: quay.io/centos-bootc/fedora-bootc:eln
     steps:
       - name: Download
         uses: actions/download-artifact@v3

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -118,6 +118,13 @@ pub(crate) enum InstallOpts {
     ToDisk(crate::install::InstallToDiskOpts),
     /// Install to the target filesystem
     ToFilesystem(crate::install::InstallToFilesystemOpts),
+    /// Output JSON to stdout that contains the merged installation configuration
+    /// as it may be relevant to calling processes using `install to-filesystem`
+    /// that want to honor e.g. `root-fs-type`.
+    ///
+    /// At the current time, the only output key is `root-fs-type` which is a string-valued
+    /// filesystem name suitable for passing to `mkfs.$type`.
+    PrintConfiguration,
 }
 
 /// Options for man page generation
@@ -522,6 +529,7 @@ async fn run_from_opt(opt: Opt) -> Result<()> {
         Opt::Install(opts) => match opts {
             InstallOpts::ToDisk(opts) => crate::install::install_to_disk(opts).await,
             InstallOpts::ToFilesystem(opts) => crate::install::install_to_filesystem(opts).await,
+            InstallOpts::PrintConfiguration => crate::install::print_configuration(),
         },
         #[cfg(feature = "install")]
         Opt::ExecInHostMountNamespace { args } => {

--- a/manpages-md/bootc-install-print-configuration.md
+++ b/manpages-md/bootc-install-print-configuration.md
@@ -1,0 +1,34 @@
+# NAME
+
+bootc-install-print-configuration - Output JSON to stdout that contains
+the merged installation configuration as it may be relevant to calling
+processes using \`install to-filesystem\` that want to honor e.g.
+\`root-fs-type\`
+
+# SYNOPSIS
+
+**bootc-install-print-configuration** \[**-h**\|**\--help**\]
+\[**-V**\|**\--version**\]
+
+# DESCRIPTION
+
+Output JSON to stdout that contains the merged installation
+configuration as it may be relevant to calling processes using \`install
+to-filesystem\` that want to honor e.g. \`root-fs-type\`.
+
+At the current time, the only output key is \`root-fs-type\` which is a
+string-valued filesystem name suitable for passing to \`mkfs.\$type\`.
+
+# OPTIONS
+
+**-h**, **\--help**
+
+:   Print help (see a summary with -h)
+
+**-V**, **\--version**
+
+:   Print version
+
+# VERSION
+
+v0.1.0

--- a/manpages-md/bootc-install-to-disk.md
+++ b/manpages-md/bootc-install-to-disk.md
@@ -5,11 +5,12 @@ bootc-install-to-disk - Install to the target block device
 # SYNOPSIS
 
 **bootc-install-to-disk** \[**\--wipe**\] \[**\--block-setup**\]
-\[**\--filesystem**\] \[**\--root-size**\] \[**\--target-transport**\]
-\[**\--target-imgref**\] \[**\--enforce-container-sigpolicy**\]
-\[**\--target-ostree-remote**\] \[**\--skip-fetch-check**\]
-\[**\--disable-selinux**\] \[**\--karg**\] \[**\--generic-image**\]
-\[**-h**\|**\--help**\] \[**-V**\|**\--version**\] \<*DEVICE*\>
+\[**\--filesystem**\] \[**\--root-size**\] \[**\--source-imgref**\]
+\[**\--target-transport**\] \[**\--target-imgref**\]
+\[**\--enforce-container-sigpolicy**\] \[**\--target-ostree-remote**\]
+\[**\--skip-fetch-check**\] \[**\--disable-selinux**\] \[**\--karg**\]
+\[**\--generic-image**\] \[**\--via-loopback**\] \[**-h**\|**\--help**\]
+\[**-V**\|**\--version**\] \<*DEVICE*\>
 
 # DESCRIPTION
 
@@ -44,6 +45,16 @@ unlock of filesystem to presence of the default tpm2 device.\
     specifiers: M (mebibytes), G (gibibytes), T (tebibytes).
 
 By default, all remaining space on the disk will be used.
+
+**\--source-imgref**=*SOURCE_IMGREF*
+
+:   Install the system from an explicitly given source.
+
+By default, bootc install and install-to-filesystem assumes that it runs
+in a podman container, and it takes the container image to install from
+the podmans container registry. If \--source-imgref is given, bootc uses
+it as the installation source, instead of the behaviour explained in the
+previous paragraph. See skopeo(1) for accepted formats.
 
 **\--target-transport**=*TARGET_TRANSPORT* \[default: registry\]
 
@@ -93,6 +104,10 @@ disabled but where the target does have SELinux enabled.
 
 \- All bootloader types will be installed - Changes to the system
 firmware will be skipped
+
+**\--via-loopback**
+
+:   Instead of targeting a block device, write to a file via loopback
 
 **-h**, **\--help**
 

--- a/manpages-md/bootc-install-to-filesystem.md
+++ b/manpages-md/bootc-install-to-filesystem.md
@@ -6,11 +6,11 @@ bootc-install-to-filesystem - Install to the target filesystem
 
 **bootc-install-to-filesystem** \[**\--root-mount-spec**\]
 \[**\--root-options**\] \[**\--boot-mount-spec**\] \[**\--replace**\]
-\[**\--target-transport**\] \[**\--target-imgref**\]
-\[**\--enforce-container-sigpolicy**\] \[**\--target-ostree-remote**\]
-\[**\--skip-fetch-check**\] \[**\--disable-selinux**\] \[**\--karg**\]
-\[**\--generic-image**\] \[**-h**\|**\--help**\]
-\[**-V**\|**\--version**\] \<*ROOT_PATH*\>
+\[**\--source-imgref**\] \[**\--target-transport**\]
+\[**\--target-imgref**\] \[**\--enforce-container-sigpolicy**\]
+\[**\--target-ostree-remote**\] \[**\--skip-fetch-check**\]
+\[**\--disable-selinux**\] \[**\--karg**\] \[**\--generic-image**\]
+\[**-h**\|**\--help**\] \[**-V**\|**\--version**\] \<*ROOT_PATH*\>
 
 # DESCRIPTION
 
@@ -53,6 +53,16 @@ be used.
 >     bootloader state will have its contents wiped and replaced.
 >     However, the running system (and all files) will remain in place
 >     until reboot
+
+**\--source-imgref**=*SOURCE_IMGREF*
+
+:   Install the system from an explicitly given source.
+
+By default, bootc install and install-to-filesystem assumes that it runs
+in a podman container, and it takes the container image to install from
+the podmans container registry. If \--source-imgref is given, bootc uses
+it as the installation source, instead of the behaviour explained in the
+previous paragraph. See skopeo(1) for accepted formats.
 
 **\--target-transport**=*TARGET_TRANSPORT* \[default: registry\]
 

--- a/manpages-md/bootc-install.md
+++ b/manpages-md/bootc-install.md
@@ -35,6 +35,12 @@ bootc-install-to-filesystem(8)
 
 :   Install to the target filesystem
 
+bootc-install-print-configuration(8)
+
+:   Output JSON to stdout that contains the merged installation
+    configuration as it may be relevant to calling processes using
+    \`install to-filesystem\` that want to honor e.g. \`root-fs-type\`
+
 bootc-install-help(8)
 
 :   Print this message or the help of the given subcommand(s)


### PR DESCRIPTION
Even when an external process is creating the disk, we want it to be able to honor the root filesystem type specified in the container.