### PR TITLE
switch: Be idempotent

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -22,8 +22,8 @@ on the target, use
 bootc switch --transport oci /var/mnt/usb/myos.oci
 ```
 
-The above command can only be invoked once currently; thereafter, use `bootc upgrade`
-as normal to fetch updates from the USB device.
+The above command is only necessary once, and thereafter will be idempotent.
+Then, use `bootc upgrade --apply` to fetch and apply the update from the USB device.
 
 This process can all be automated by creating systemd
 units that look for a USB device with a specific label, mount (optionally with LUKS

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -442,7 +442,8 @@ async fn switch(opts: SwitchOpts) -> Result<()> {
     };
 
     if new_spec == host.spec {
-        anyhow::bail!("No changes in current host spec");
+        println!("Image specification is unchanged.");
+        return Ok(());
     }
     let new_spec = RequiredHostSpec::from_spec(&new_spec)?;
 

--- a/tests/kolainst/basic
+++ b/tests/kolainst/basic
@@ -15,9 +15,16 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     bootc status > status.txt
     grep 'Version:' status.txt
     bootc status --json > status.json
-    image=$(jq -r '.status.booted.image.image' < status.json)
+    image=$(jq '.status.booted.image.image' < status.json)
     echo "booted into $image"
     echo "ok status test"
+
+    # Switch should be idempotent
+    # (also TODO, get rid of the crazy .image.image.image nesting)
+    name=$(echo "${image}" | jq -r '.image')
+    bootc switch $name
+    staged=$(bootc status --json | jq .status.staged)
+    test "$staged" = "null"
 
     host_ty=$(jq -r '.status.type' < status.json)
     test "${host_ty}" = "bootcHost"


### PR DESCRIPTION
Instead of erroring out if the spec is unchanged, just print a notice.  This better matches Kubernetes default style.