### PR TITLE
install: Only switch to loopback after re-exec

### DIFF
--- a/lib/src/blockdev.rs
+++ b/lib/src/blockdev.rs
@@ -89,6 +89,7 @@ impl LoopbackDevice {
             .quiet()
             .read()?;
         let dev = Utf8PathBuf::from(dev.trim());
+        tracing::debug!("Allocated loopback {dev}");
         Ok(Self { dev: Some(dev) })
     }
 
@@ -104,6 +105,7 @@ impl LoopbackDevice {
         let dev = if let Some(dev) = self.dev.take() {
             dev
         } else {
+            tracing::trace!("loopback device already deallocated");
             return Ok(());
         };
         Task::new("losetup", "losetup")


### PR DESCRIPTION
blockdev: Add some debugging around loopback

Signed-off-by: Colin Walters <walters@verbum.org>

---

install: Only switch to loopback after re-exec

I noticed we were leaking a loopback device, and the reason is
because the "re-exec self for selinux" dance.

We should really try to move that re-exec way earlier because
it's a big hazard for stuff like this right now.

This is a simple fix though that just moves the switch to
allocating the loopback device until after we've done the install
prep (including that re-exec).

Signed-off-by: Colin Walters <walters@verbum.org>

---

