### PR TITLE
README: provide an example to generate a booting image

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ which is used to boot.  At runtime on a target system, the base userspace is
 *not* itself running in a container by default.  For example, assuming
 systemd is in use, systemd acts as pid1 as usual - there's no "outer" process.
 
+# Example
+
+To try bootc today run:
+```
+$ truncate -s 10G test-disk.img
+$ sudo losetup -Pf test-disk.img
+$ LOOP=$(sudo losetup | grep test-disk.img | cut -f1 -d' ')
+$ sudo podman run --rm --privileged --pid=host --security-opt label=type:unconfined_t quay.io/centos-bootc/fedora-bootc:eln bootc install to-disk --generic-machine "$LOOP"
+$ qemu-system-x86_64 -m 1500 -snapshot -accel kvm -cpu host -bios /usr/share/OVMF/OVMF_CODE.fd ./test-disk.img
+```
+
+
 # More information
 
 See the [project documentation](https://containers.github.io/bootc/).


### PR DESCRIPTION
To help people get an impression of `bootc` this commit adds an example how to install bootc to a disk-image and boot it with qemu.

Arguable this example is not complete as there is no way for the user to login in right now and maybe some example how to use the host would be nice but this might be a useful start.

[draft as it's mostly here to get a discussion going if this is useful and if so if it should be in the README or somewhere else, also we might want to discuss if we use the new --via-loopback instead of this manual setup and if we can put this into the auto-testing infra]