### PR TITLE
Port to ostree-ext 0.13, cap-std 3

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -15,11 +15,11 @@ anstream = "0.6.4"
 anstyle = "1.0.4"
 anyhow = "1.0"
 camino = { version = "1.0.4", features = ["serde1"] }
-ostree-ext = { version = "0.12.8" }
+ostree-ext = { version = "0.13" }
 chrono = { version = "0.4.23", features = ["serde"] }
 clap = { version= "4.2", features = ["derive"] }
 clap_mangen = { version = "0.2", optional = true }
-cap-std-ext = "3"
+cap-std-ext = "4"
 hex = "^0.4"
 fn-error-context = "0.2.0"
 gvariant = "0.4.0"

--- a/lib/src/deploy.rs
+++ b/lib/src/deploy.rs
@@ -5,7 +5,7 @@
 use anyhow::Ok;
 use anyhow::{Context, Result};
 
-use cap_std::fs::Dir;
+use cap_std::fs::{Dir, MetadataExt};
 use cap_std_ext::cap_std;
 use cap_std_ext::dirext::CapStdExtDirExt;
 use fn_error_context::context;
@@ -16,7 +16,6 @@ use ostree_ext::container::store::PrepareResult;
 use ostree_ext::ostree;
 use ostree_ext::ostree::Deployment;
 use ostree_ext::sysroot::SysrootLock;
-use rustix::fs::MetadataExt;
 
 use crate::spec::HostSpec;
 use crate::spec::ImageReference;
@@ -315,7 +314,7 @@ pub(crate) fn switch_origin_inplace(root: &Dir, imgref: &ImageReference) -> Resu
 
 #[test]
 fn test_switch_inplace() -> Result<()> {
-    use std::os::unix::fs::DirBuilderExt;
+    use cap_std::fs::DirBuilderExt;
 
     let td = cap_std_ext::cap_tempfile::TempDir::new(cap_std::ambient_authority())?;
     let mut builder = cap_std::fs::DirBuilder::new();

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -20,14 +20,13 @@ use anyhow::Ok;
 use anyhow::{anyhow, Context, Result};
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
-use cap_std::fs::Dir;
+use cap_std::fs::{Dir, MetadataExt};
 use cap_std_ext::cap_std;
 use cap_std_ext::prelude::CapStdExtDirExt;
 use chrono::prelude::*;
 use clap::ValueEnum;
 use ostree_ext::oci_spec;
 use rustix::fs::FileTypeExt;
-use rustix::fs::MetadataExt;
 
 use fn_error_context::context;
 use ostree::gio;
@@ -691,8 +690,7 @@ async fn initialize_ostree_root_from_self(
 
     let uname = rustix::system::uname();
 
-    let config = state.configuration.as_ref();
-    let labels = config.and_then(crate::status::labels_of_config);
+    let labels = crate::status::labels_of_config(&state.configuration);
     let timestamp = labels
         .and_then(|l| {
             l.get(oci_spec::image::ANNOTATION_CREATED)


### PR DESCRIPTION
Main changes are

- Configuration object is no longer an `Option<T>`
- The metadata trait extensions now must be from cap-std