### PR TITLE
Fix install_t again

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -293,7 +293,9 @@ pub(crate) async fn prepare_for_write() -> Result<()> {
     }
     ensure_self_unshared_mount_namespace().await?;
     if crate::lsm::selinux_enabled()? {
-        crate::lsm::selinux_ensure_install()?;
+        if !crate::lsm::selinux_ensure_install()? {
+            tracing::warn!("Do not have install_t capabilities");
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
lsm: Make setenforce 0 fallback require `BOOTC_SETENFORCE0_FALLBACK`

We shouldn't perform global system mutation without an opt-in.
As painful as it is.

Signed-off-by: Colin Walters <walters@verbum.org>

---

lsm: Test if we have install_t capability

Hardcoding `install_t` is a bit ugly; maybe at some point
things change so that `spc_t` has `install_t` privileges.

Let's do a runtime check if we can set an invalid label; if
so then we're good.

Signed-off-by: Colin Walters <walters@verbum.org>

---

lsm: Make a not-`nosuid` `/tmp`

This was the thing that was breaking our `unconfined_t` -> `install_t`
transition; the host `/tmp` is `nosuid`.  It simplifies things
here to just make our own, so do that.

Signed-off-by: Colin Walters <walters@verbum.org>

---

