### PR TITLE
install: Optionally use host mounted `/var/lib/containers`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,39 +116,13 @@ jobs:
         run: sudo tar -C / -xvf bootc.tar.zst
       - name: Integration tests
         run: bootc internal-tests run-container-integration
-  build-skopeo-ubuntu:
-    name: "Build skopeo git main for ubuntu"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          repository: containers/skopeo
-          path: skopeo
-      - name: Install build deps
-        run: |
-          sudo sed -ie s,'# deb-src,deb-src,' /etc/apt/sources.list
-          sudo apt update
-          sudo apt build-dep -y skopeo
-      - uses: actions/setup-go@v4
-        with:
-          go-version: '>=1.20'
-      - name: Build skopeo
-        run: cd skopeo && make bin/skopeo PREFIX=/usr
-      - name: Upload binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: skopeo-ubuntu
-          path: skopeo/bin/skopeo
   privtest-alongside:
     name: "Test install-alongside"
-    needs: [build-fedora, build-skopeo-ubuntu]
+    needs: [build-fedora]
     runs-on: ubuntu-latest
     steps:
-      - name: Download
-        uses: actions/download-artifact@v4
-        with:
-          name: skopeo-ubuntu
-      - run: chmod a+x skopeo && sudo mv skopeo /usr/bin
+      - name: Ensure host skopeo is disabled
+        run: sudo rm -f /bin/skopeo /usr/bin/skopeo
       - name: Download
         uses: actions/download-artifact@v3
         with:
@@ -158,7 +132,7 @@ jobs:
       - name: Integration tests
         run: |
           set -xeuo pipefail
-          sudo podman run --rm -ti --privileged -v /:/target -v ./usr/bin/bootc:/usr/bin/bootc --pid=host --security-opt label=disable \
+          sudo podman run --rm -ti --privileged --env RUST_LOG=debug -v /:/target -v /var/lib/containers:/var/lib/containers -v ./usr/bin/bootc:/usr/bin/bootc --pid=host --security-opt label=disable \
             quay.io/centos-bootc/fedora-bootc-dev:eln bootc install to-filesystem \
             --karg=foo=bar --disable-selinux --replace=alongside /target
           ls -al /boot/loader/

--- a/lib/src/podman.rs
+++ b/lib/src/podman.rs
@@ -4,6 +4,10 @@ use serde::Deserialize;
 use crate::install::run_in_host_mountns;
 use crate::task::Task;
 
+/// Where we look inside our container to find our own image
+/// for use with `bootc install`.
+pub(crate) const CONTAINER_STORAGE: &str = "/var/lib/containers";
+
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub(crate) struct Inspect {


### PR DESCRIPTION
I just keep hitting the host skopeo requirement in corner cases; it's annoying because *otherwise* the container is self-sufficient. Change our installation instructions to add a `/var/lib/containers` bind mount.

For the time being of course we continue to support forking off `skopeo` on the host.

One thing I still want to investigate is dropping some requirements here and switch to *dynamically* setting up the mount points inside the container as is mentioned in https://brauner.io/2023/02/28/mounting-into-mount-namespaces.html but this currently requires relatively new host kernels.

As far as test coverage, this changes the Github Action that uses ubuntu and needed to build a newer skopeo to stop doing that, and in fact we explicitly *remove* skopeo to verify it's not being used in the install process.

I didn't change the other install tests to verify they keep working.

Closes: https://github.com/containers/bootc/issues/81