### PR TITLE
install: Ensure we label `/` (and `/boot`)

### DIFF
--- a/tests/kolainst/install
+++ b/tests/kolainst/install
@@ -40,6 +40,9 @@ EOF
     grep -Ee '^linux /boot/ostree' /var/mnt/loader/entries/*.conf
     umount /var/mnt
     echo "ok install"
+    mount /dev/vda4 /var/mnt
+    ls -dZ /var/mnt |grep ':root_t:'
+    umount /var/mnt
 
     # Now test install to-filesystem
     # Wipe the device


### PR DESCRIPTION
This came out of a discussion with bootc-image-builder, which has this issue right now:
https://github.com/osbuild/bootc-image-builder/issues/149

As I noted in that issue, I think it's basically been working here because we always write to a real fresh filesystem, but let's be very explicit.

There's a notable tricky bootstrapping we're solving here around "what's the label of `/`" because we know we are running the target OS as a container image already.