### PR TITLE
lsm: send test_install_t chcon output to /dev/null

### DIFF
--- a/lib/src/lsm.rs
+++ b/lib/src/lsm.rs
@@ -39,6 +39,7 @@ fn test_install_t() -> Result<bool> {
     let st = Command::new("chcon")
         .args(["-t", "invalid_bootcinstall_testlabel_t"])
         .arg(tmpf.path())
+        .stderr(std::process::Stdio::null())
         .status()?;
     Ok(st.success())
 }


### PR DESCRIPTION
Otherwise it's noisy:

```
[root@localhost ~]# ./bootc update --check
chcon: failed to change context of '/tmp/.tmp2rw6pV' to ‘unconfined_u:object_r:invalid_bootcinstall_testlabel_t:s0’: Invalid argument
chcon: failed to change context of '/tmp/.tmpCiTvUm' to ‘unconfined_u:object_r:invalid_bootcinstall_testlabel_t:s0’: Invalid argument
No changes in: ostree-unverified-registry:quay.io/centos-bootc/fedora-bootc-cloud:eln
[root@localhost ~]#
```