### PR TITLE
install: Add BOOTC_SKIP_SELINUX_HOST_CHECK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,3 +137,10 @@ jobs:
             --karg=foo=bar --disable-selinux --replace=alongside /target
           ls -al /boot/loader/
           sudo grep foo=bar /boot/loader/entries/*.conf
+          # TODO fix https://github.com/containers/bootc/pull/137
+          sudo chattr -i / /ostree/deploy/default/deploy/*
+          sudo rm /ostree/deploy/default -rf
+          sudo podman run --rm -ti --privileged --env BOOTC_SKIP_SELINUX_HOST_CHECK=1 --env RUST_LOG=debug -v /:/target -v /var/lib/containers:/var/lib/containers -v ./usr/bin/bootc:/usr/bin/bootc --pid=host --security-opt label=disable \
+            quay.io/centos-bootc/fedora-bootc-dev:eln bootc install to-filesystem \
+            --replace=alongside /target
+          sudo ls -ldZ / /ostree/deploy/default/deploy/* /ostree/deploy/default/deploy/*/etc

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -707,6 +707,10 @@ pub(crate) fn reexecute_self_for_selinux_if_needed(
     let mut ret_did_override = false;
     // If the target state has SELinux enabled, we need to check the host state.
     let mut g = None;
+    // We don't currently quite support installing SELinux enabled systems
+    // from SELinux disabled hosts, but this environment variable can be set
+    // to test it out anyways.
+    let skip_check_envvar = "BOOTC_SKIP_SELINUX_HOST_CHECK";
     if srcdata.selinux {
         let host_selinux = crate::lsm::selinux_enabled()?;
         tracing::debug!("Target has SELinux, host={host_selinux}");
@@ -722,6 +726,11 @@ pub(crate) fn reexecute_self_for_selinux_if_needed(
         } else if override_disable_selinux {
             ret_did_override = true;
             println!("notice: Target has SELinux enabled, overriding to disable")
+        } else if std::env::var_os(skip_check_envvar).is_some() {
+            eprintln!(
+                "Host kernel does not have SELinux support, but target enables it by default; {} is set, continuing anyways",
+                skip_check_envvar
+            );
         } else {
             anyhow::bail!(
                 "Host kernel does not have SELinux support, but target enables it by default"


### PR DESCRIPTION
We're going to investigate supporting installing SELinux-enabled targets from a SELinux-disabled host.  This environment variable will allow bypassing the check.

xref https://github.com/ostreedev/ostree/pull/3151