### PR TITLE
lsm: Forcibly relabel all initial state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,4 +143,4 @@ jobs:
           sudo podman run --rm -ti --privileged --env BOOTC_SKIP_SELINUX_HOST_CHECK=1 --env RUST_LOG=debug -v /:/target -v /var/lib/containers:/var/lib/containers -v ./usr/bin/bootc:/usr/bin/bootc --pid=host --security-opt label=disable \
             quay.io/centos-bootc/fedora-bootc-dev:eln bootc install to-filesystem \
             --replace=alongside /target
-          sudo ls -ldZ / /ostree/deploy/default/deploy/* /ostree/deploy/default/deploy/*/etc
+          sudo ls -ldZ / /boot /ostree/deploy/default /ostree/repo/objects /ostree/deploy/default/deploy/* /ostree/deploy/default/deploy/*/etc

--- a/lib/src/install/baseline.rs
+++ b/lib/src/install/baseline.rs
@@ -364,15 +364,10 @@ pub(crate) fn install_create_rootfs(
         .collect::<Vec<_>>();
 
     mount::mount(&rootdev, &rootfs)?;
-    state.lsm_label(&rootfs, "/".into(), false)?;
     let rootfs_fd = Dir::open_ambient_dir(&rootfs, cap_std::ambient_authority())?;
     let bootfs = rootfs.join("boot");
     std::fs::create_dir(&bootfs).context("Creating /boot")?;
-    // The underlying directory on the root should be labeled
-    state.lsm_label(&bootfs, "/boot".into(), false)?;
     mount::mount(bootdev, &bootfs)?;
-    // And we want to label the root mount of /boot
-    state.lsm_label(&bootfs, "/boot".into(), false)?;
 
     // Create the EFI system partition, if applicable
     if let Some(esp_partno) = esp_partno {


### PR DESCRIPTION
This is attempting to handle the "install selinux-enabled target from selinux-disabled host". We're kind of papering over effectively ostree design bugs here as in this case libostree itself should be setting the labels, but doing that is a bit hard and awkward right now.