### PR TITLE
Update bootc-fetch-apply-updates.timer with comments for RandomizedDe…

### DIFF
--- a/systemd/bootc-fetch-apply-updates.timer
+++ b/systemd/bootc-fetch-apply-updates.timer
@@ -7,6 +7,8 @@ ConditionPathExists=/run/ostree-booted
 OnBootSec=1h
 # This time is relatively arbitrary and obviously expected to be overridden/changed
 OnUnitInactiveSec=8h
+# When deploying a large number of systems, it may be beneficial to increase this value to help with load on the registry.
+RandomizedDelaySec=2h
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
…laySec=

RandomizedDelaySec= is the best kept secret of timers. Given that such few people know about it and it's very useful for large deployments, I think it makes sense to add it as a comment.

Thoughts about providing this out of the box as a comment? I'm not proposing we turn it on by default. 