### PR TITLE
Drop status warning

### DIFF
--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -1018,8 +1018,9 @@ pub(crate) async fn install_to_disk(mut opts: InstallToDiskOpts) -> Result<()> {
         .with_context(|| format!("Querying {}", &block_opts.device))?;
     if opts.via_loopback {
         if !opts.config_opts.generic_image {
-            eprintln!("Automatically enabling --generic-image when installing via loopback");
-            std::thread::sleep(std::time::Duration::from_secs(2));
+            crate::utils::medium_visibility_warning(
+                "Automatically enabling --generic-image when installing via loopback",
+            );
             opts.config_opts.generic_image = true;
         }
         if !target_blockdev_meta.file_type().is_file() {

--- a/lib/src/status.rs
+++ b/lib/src/status.rs
@@ -299,8 +299,6 @@ pub(crate) async fn status(opts: super::cli::StatusOpts) -> Result<()> {
         host
     };
 
-    crate::utils::warning("note: The format of this API is not yet stable");
-
     // If we're in JSON mode, then convert the ostree data into Rust-native
     // structures that can be serialized.
     // Filter to just the serializable status structures.

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -67,13 +67,16 @@ pub(crate) fn sigpolicy_from_opts(
     }
 }
 
-/// Output a warning message
-pub(crate) fn warning(s: &str) {
+/// Output a warning message that we want to be quite visible.
+/// The process (thread) execution will be delayed for a short time.
+pub(crate) fn medium_visibility_warning(s: &str) {
     anstream::eprintln!(
         "{}{s}{}",
         anstyle::AnsiColor::Red.render_fg(),
         anstyle::Reset.render()
     );
+    // When warning, add a sleep to ensure it's seen
+    std::thread::sleep(std::time::Duration::from_secs(1));
 }
 
 /// Given a possibly tagged image like quay.io/foo/bar:latest and a digest 0ab32..., return


### PR DESCRIPTION
status: Drop warning

Per the issue, having the API format be `v1alpha` is enough.

Closes: https://github.com/containers/bootc/issues/297
Signed-off-by: Colin Walters <walters@verbum.org>

---

Adapt warning API for usage in install

The `warning` helper API just became unused by the previous
commit; make it used in another place it should have been.

Signed-off-by: Colin Walters <walters@verbum.org>

---

