### PR TITLE
Add suggestion for `LABEL containers.bootc 1`

### DIFF
--- a/docs/bootc-images.md
+++ b/docs/bootc-images.md
@@ -50,6 +50,16 @@ The requirement for both methods is that your initial treefile/manifest
 However, the ostree usage is an implementation detail
 and the requirement on this will be lifted in the future.
 
+## Standard metadata for bootc compatible images
+
+It is strongly recommended to do:
+
+```dockerfile
+LABEL containers.bootc 1
+```
+
+This will signal that this image is intended to be usable with `bootc`.
+
 # Deriving from existing base images
 
 It's important to emphasize that from one

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -26,6 +26,7 @@ gvariant = "0.4.0"
 indicatif = "0.17.0"
 libc = "^0.2"
 liboverdrop = "0.1.0"
+libsystemd = "0.7"
 once_cell = "1.9"
 openssl = "^0.10"
 # TODO drop this in favor of rustix

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -341,6 +341,7 @@ async fn upgrade(opts: UpgradeOpts) -> Result<()> {
                 println!("No changes in: {}", imgref);
             }
             PrepareResult::Ready(r) => {
+                crate::deploy::check_bootc_label(&r.config);
                 println!("Update available for: {}", imgref);
                 if let Some(version) = r.version() {
                     println!("  Version: {version}");

--- a/lib/src/journal.rs
+++ b/lib/src/journal.rs
@@ -1,0 +1,36 @@
+//! Thin wrapper for systemd journaling; these APIs are no-ops
+//! when not running under systemd.  Only use them when
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Set to true if we failed to write to the journal once
+static EMITTED_JOURNAL_ERROR: AtomicBool = AtomicBool::new(false);
+
+/// Wrapper for structured logging which is an explicit no-op
+/// when systemd is not in use (e.g. in a container).
+pub(crate) fn journal_send<K, V>(
+    priority: libsystemd::logging::Priority,
+    msg: &str,
+    vars: impl Iterator<Item = (K, V)>,
+) where
+    K: AsRef<str>,
+    V: AsRef<str>,
+{
+    if !libsystemd::daemon::booted() {
+        return;
+    }
+    if let Err(e) = libsystemd::logging::journal_send(priority, msg, vars) {
+        if !EMITTED_JOURNAL_ERROR.swap(true, Ordering::SeqCst) {
+            eprintln!("failed to write to journal: {e}");
+        }
+    }
+}
+
+/// Wrapper for writing to systemd journal which is an explicit no-op
+/// when systemd is not in use (e.g. in a container).
+#[allow(dead_code)]
+pub(crate) fn journal_print(priority: libsystemd::logging::Priority, msg: &str) {
+    let vars: HashMap<&str, &str> = HashMap::new();
+    journal_send(priority, msg, vars.into_iter())
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -19,7 +19,9 @@
 
 pub mod cli;
 pub(crate) mod deploy;
+pub(crate) mod journal;
 mod lsm;
+pub(crate) mod metadata;
 mod reboot;
 mod reexec;
 mod status;

--- a/lib/src/metadata.rs
+++ b/lib/src/metadata.rs
@@ -1,0 +1,4 @@
+/// This label is expected to be present on compatible base images.
+pub(crate) const BOOTC_COMPAT_LABEL: &str = "containers.bootc";
+/// The current single well-known value for the label.
+pub(crate) const COMPAT_LABEL_V1: &str = "1";


### PR DESCRIPTION
As we aim to slowly move away from ostree, let's add a bootc label that we expect to be used.  For now, this is just a warning.

I will change rpm-ostree to add this by default if we take this.

But this one is also an important step for if we ever add the flow of simply deriving from an existing application base image.