### PR TITLE
deploy: Log filtered content warning to journal, not stderr

### DIFF
--- a/lib/src/deploy.rs
+++ b/lib/src/deploy.rs
@@ -148,7 +148,7 @@ pub(crate) async fn pull(
     if let Some(msg) =
         ostree_container::store::image_filtered_content_warning(repo, &imgref.imgref)?
     {
-        eprintln!("{msg}")
+        crate::journal::journal_print(libsystemd::logging::Priority::Notice, &msg);
     }
     Ok(Box::new((*import).into()))
 }


### PR DESCRIPTION
This one is really a "soft warning"...it's not a serious problem to have stuff in `/run`, it's just ignored.

At the same time, we want to persist it so that someone debugging things later can find the information.