### PR TITLE
ci: Add renovate5

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,66 @@
+/*
+   Renovate is a service similar to GitHub Dependabot, but with
+   (fantastically) more configuration options.  So many options
+   in fact, if you're new I recommend glossing over this cheat-sheet
+   prior to the official documentation:
+
+   https://www.augmentedmind.de/2021/07/25/renovate-bot-cheat-sheet
+
+   Configuration Update/Change Procedure:
+     1. Make changes
+     2. Manually validate changes (from repo-root):
+
+        podman run -it \
+            -v ./.github/renovate.json5:/usr/src/app/renovate.json5:z \
+            docker.io/renovate/renovate:latest \
+            renovate-config-validator
+     3. Commit.
+
+   Configuration Reference:
+   https://docs.renovatebot.com/configuration-options/
+
+   Monitoring Dashboard:
+   https://app.renovatebot.com/dashboard#github/containers
+
+   Note: The Renovate bot will create/manage it's business on
+         branches named 'renovate/*'.  Otherwise, and by
+         default, the only the copy of this file that matters
+         is the one on the `main` branch.  No other branches
+         will be monitored or touched in any way.
+*/
+
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
+  /*************************************************
+   ****** Global/general configuration options *****
+   *************************************************/
+
+  // Re-use predefined sets of configuration options to DRY
+  "extends": [
+    // https://github.com/containers/automation/blob/main/renovate/defaults.json5
+    "github>containers/automation//renovate/defaults.json5"
+  ],
+
+  // Permit automatic rebasing when base-branch changes by more than
+  // one commit.
+  "rebaseWhen": "behind-base-branch",
+
+  /*************************************************
+   *** Repository-specific configuration options ***
+   *************************************************/
+
+  // Don't leave dep. update. PRs "hanging", assign them to people.
+  // "assignees": ["containers/netavark-maintainers"],
+
+  /**************************************************
+   ***** Manager-specific configuration options *****
+   **************************************************/
+
+  "dockerfile": {
+      // Renovate has a hard-time managing base images for
+      // Fedora and CentOS (see contrib/container_images/).  Disable
+      // all Dockerfile baes-image management.
+      "enabled": false
+  },
+}


### PR DESCRIPTION
Right now we're not using a `Cargo.lock`, but we should.  Let's try out renovate like some other Rust containers/ GH repos.

e.g. https://github.com/containers/netavark/commit/67b7da4a89e55ab4a94c450971f2e0d0a5983310

I commented out the assignee thing as we don't have a dedicated team yet.