### PR TITLE
install: Drop setting immutable bit on physical /

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
           sudo grep foo=bar /boot/loader/entries/*.conf
           grep authorized_keys /ostree/deploy/default/deploy/*/etc/tmpfiles.d/bootc-root-ssh.conf
           # TODO fix https://github.com/containers/bootc/pull/137
-          sudo chattr -i / /ostree/deploy/default/deploy/*
+          sudo chattr -i /ostree/deploy/default/deploy/*
           sudo rm /ostree/deploy/default -rf
           sudo podman run --rm -ti --privileged --env BOOTC_SKIP_SELINUX_HOST_CHECK=1 --env RUST_LOG=debug -v /:/target -v /var/lib/containers:/var/lib/containers -v ./usr/bin/bootc:/usr/bin/bootc --pid=host --security-opt label=disable \
             quay.io/centos-bootc/fedora-bootc-dev:eln bootc install to-filesystem \

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -1012,13 +1012,6 @@ async fn install_to_filesystem_impl(state: &State, rootfs: &mut RootSetup) -> Re
     crate::bootloader::install_via_bootupd(&rootfs.device, &rootfs.rootfs, &state.config_opts)?;
     tracing::debug!("Installed bootloader");
 
-    // ostree likes to have the immutable bit on the physical sysroot to ensure
-    // that it doesn't accumulate junk; all system state should be in deployments.
-    Task::new("Setting root immutable bit", "chattr")
-        .cwd(&rootfs.rootfs_fd)?
-        .args(["+i", "."])
-        .run()?;
-
     // Finalize mounted filesystems
     if !rootfs.is_alongside {
         let bootfs = rootfs.rootfs.join("boot");


### PR DESCRIPTION
I've gone back and forth on this one over time; lately my thought is that conceptually `/` is stuff that bootc/ostree doesn't actually own, and so we shouldn't add this bit.

For a use case of e.g. testing out bootc via an "alongside" install, we would want to enable rolling back to the non-bootc state (at some point in the future when we e.g. save the original `/boot`) and the immutable bit would be a thing we'd then need to undo.

The readonly bind mount over `/sysroot` should be sufficient for our use cases.