### PR TITLE
renovate: just do patch updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -48,13 +48,12 @@
 
   "packageRules": [
     {
-      "groupName": "all non-major dependencies",
-      "groupSlug": "all-minor-patch",
+      "groupName": "all patch dependencies",
+      "groupSlug": "all-patch",
       "matchPackagePatterns": [
         "*"
       ],
       "matchUpdateTypes": [
-        "minor",
         "patch"
       ]
     }


### PR DESCRIPTION
Renovate apparently doesn't understand that in Rust for pre-1.0 crates that "minor" are actually semver bumps.