### PR TITLE
hack: Allow injecting stuff into target/dev-rootfs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .cosa
 target
+!target/dev-rootfs

--- a/hack/Containerfile
+++ b/hack/Containerfile
@@ -4,10 +4,12 @@ FROM quay.io/centos-bootc/fedora-bootc:eln as build
 RUN dnf config-manager --set-enabled eln-crb && dnf -y install cargo ostree-devel openssl-devel && dnf clean all
 COPY . /build
 WORKDIR /build
+RUN mkdir -p /build/target/dev-rootfs  # This can hold arbitrary extra content
 # See https://www.reddit.com/r/rust/comments/126xeyx/exploring_the_problem_of_faster_cargo_docker/
 # We aren't using the full recommendations there, just the simple bits.
 RUN --mount=type=cache,target=/build/target --mount=type=cache,target=/var/roothome make bin-archive && mkdir -p /out && cp target/bootc.tar.zst /out
 
 FROM quay.io/centos-bootc/fedora-bootc:eln
 COPY --from=build /out/bootc.tar.zst /tmp
+COPY --from=build /build/target/dev-rootfs/ /
 RUN tar -C / --zstd -xvf /tmp/bootc.tar.zst && rm -vf /tmp/*


### PR DESCRIPTION
Specifically, I want to hack on both e.g. ostree and bootc at the same time.  With this, I can do (from ostree):

```bash
$ make install DESTDIR=/path/to/bootc/target/dev-rootfs
```

Then from this repo, running a container build will get me both.