### PR TITLE
Track ostree-ext git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,8 +1295,7 @@ dependencies = [
 [[package]]
 name = "ostree-ext"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6a8849d4e9c8fce29b3c859b4d5e6d15b6cb55401fce34624178d06f402e7e"
+source = "git+https://github.com/ostreedev/ostree-rs-ext?rev=cb9eab9b7d1061bcdc2b797c7370aa8d21375b2f#cb9eab9b7d1061bcdc2b797c7370aa8d21375b2f"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/contrib/packaging/bootc.spec
+++ b/contrib/packaging/bootc.spec
@@ -40,6 +40,11 @@ cat >>.cargo/config.toml << EOF
 [source.crates-io]
 replace-with = "vendored-sources"
 
+[source."git+https://github.com/ostreedev/ostree-rs-ext?rev=cb9eab9b7d1061bcdc2b797c7370aa8d21375b2f"]
+git = "https://github.com/ostreedev/ostree-rs-ext"
+rev = "cb9eab9b7d1061bcdc2b797c7370aa8d21375b2f"
+replace-with = "vendored-sources"
+
 [source.vendored-sources]
 directory = "vendor"
 EOF

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -15,7 +15,7 @@ anstream = "0.6.11"
 anstyle = "1.0.6"
 anyhow = "1.0"
 camino = { version = "1.0.4", features = ["serde1"] }
-ostree-ext = { version = "0.13" }
+ostree-ext = { version = "0.13", git = "https://github.com/ostreedev/ostree-rs-ext", rev = "cb9eab9b7d1061bcdc2b797c7370aa8d21375b2f" }
 chrono = { version = "0.4.23", features = ["serde"] }
 clap = { version= "4.2", features = ["derive"] }
 clap_mangen = { version = "0.2", optional = true }


### PR DESCRIPTION
This way we'll get the updated `/var` handling in our -dev images for ease of testing.