### PR TITLE
Update to ostree-ext 0.13.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,8 +1294,9 @@ dependencies = [
 
 [[package]]
 name = "ostree-ext"
-version = "0.13.1"
-source = "git+https://github.com/ostreedev/ostree-rs-ext?rev=cb9eab9b7d1061bcdc2b797c7370aa8d21375b2f#cb9eab9b7d1061bcdc2b797c7370aa8d21375b2f"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc9d8c25b2603db582fb3786a2c3a4af7b874e11ebda1a04f151d307d4dc6fe"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/contrib/packaging/bootc.spec
+++ b/contrib/packaging/bootc.spec
@@ -40,11 +40,6 @@ cat >>.cargo/config.toml << EOF
 [source.crates-io]
 replace-with = "vendored-sources"
 
-[source."git+https://github.com/ostreedev/ostree-rs-ext?rev=cb9eab9b7d1061bcdc2b797c7370aa8d21375b2f"]
-git = "https://github.com/ostreedev/ostree-rs-ext"
-rev = "cb9eab9b7d1061bcdc2b797c7370aa8d21375b2f"
-replace-with = "vendored-sources"
-
 [source.vendored-sources]
 directory = "vendor"
 EOF

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -15,7 +15,7 @@ anstream = "0.6.11"
 anstyle = "1.0.6"
 anyhow = "1.0"
 camino = { version = "1.1.6", features = ["serde1"] }
-ostree-ext = { version = "0.13", git = "https://github.com/ostreedev/ostree-rs-ext", rev = "cb9eab9b7d1061bcdc2b797c7370aa8d21375b2f" }
+ostree-ext = { version = "0.13.2"  }
 chrono = { version = "0.4.34", features = ["serde"] }
 clap = { version= "4.5", features = ["derive"] }
 clap_mangen = { version = "0.2", optional = true }


### PR DESCRIPTION
I decided to just do a release anyways, so we don't need to track git.

This (effectively) reverts commit 79295cedaf0135c9e9dd5505575921d8a46d45ba.