### PR TITLE
Make `--disable-selinux` work on hosts that have `selinux=0`

### DIFF
--- a/lib/src/lsm.rs
+++ b/lib/src/lsm.rs
@@ -24,8 +24,9 @@ const SELF_CURRENT: &str = "/proc/self/attr/current";
 
 #[context("Querying selinux availability")]
 pub(crate) fn selinux_enabled() -> Result<bool> {
-    let filesystems = std::fs::read_to_string("/proc/filesystems")?;
-    Ok(filesystems.contains("selinuxfs\n"))
+    Path::new("/proc/1/root/sys/fs/selinux/enforce")
+        .try_exists()
+        .map_err(Into::into)
 }
 
 /// Get the current process SELinux security context


### PR DESCRIPTION
Prior to this fix the selinux_enabled function would always return true, even if selinux was set to disabled or permissive.

fixed #303 