### PR TITLE
install: Mount `/boot` readonly by default

### DIFF
--- a/lib/src/install/baseline.rs
+++ b/lib/src/install/baseline.rs
@@ -348,7 +348,12 @@ pub(crate) fn install_create_rootfs(
     let rootarg = format!("root=UUID={root_uuid}");
     let bootsrc = format!("UUID={boot_uuid}");
     let bootarg = format!("boot={bootsrc}");
-    let boot = MountSpec::new(bootsrc.as_str(), "/boot");
+    let boot = MountSpec {
+        source: bootsrc.into(),
+        target: "/boot".into(),
+        fstype: MountSpec::AUTO.into(),
+        options: Some("ro".into()),
+    };
     let kargs = root_blockdev_kargs
         .into_iter()
         .flatten()


### PR DESCRIPTION
As we want to support enabling `root.transient` in some images, this means that things like `apt|dnf install foo` literally just works out of the box.

However...we have a looming danger around things like kernels.  Typically the package installation scripts for those aren't going to handle this correctly.

Let's mount `/boot` readonly by default, as we have been doing in Fedora CoreOS and derivatives for a while.

Now I'm not totally happy with this because ultimately I think this should be configurable by the OS, not hardcoded in bootc.  We have some thought to put in to exactly how that's exposed.

But for now let's set the precedent here.