### PR TITLE
install: Drop unimplemented root_options

### DIFF
--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -214,10 +214,6 @@ pub(crate) struct InstallTargetFilesystemOpts {
     #[clap(long)]
     pub(crate) root_mount_spec: Option<String>,
 
-    /// Comma-separated mount options for the root filesystem.  For example: rw,prjquota
-    #[clap(long)]
-    pub(crate) root_options: Option<String>,
-
     /// Mount specification for the /boot filesystem.
     ///
     /// At the current time, a separate /boot is required.  This restriction will be lifted in

--- a/manpages-md/bootc-install-to-disk.md
+++ b/manpages-md/bootc-install-to-disk.md
@@ -9,7 +9,8 @@ bootc-install-to-disk - Install to the target block device
 \[**\--target-transport**\] \[**\--target-imgref**\]
 \[**\--enforce-container-sigpolicy**\] \[**\--target-ostree-remote**\]
 \[**\--skip-fetch-check**\] \[**\--disable-selinux**\] \[**\--karg**\]
-\[**\--generic-image**\] \[**\--via-loopback**\] \[**-h**\|**\--help**\]
+\[**\--root-ssh-authorized-keys**\] \[**\--generic-image**\]
+\[**\--via-loopback**\] \[**-h**\|**\--help**\]
 \[**-V**\|**\--version**\] \<*DEVICE*\>
 
 # DESCRIPTION
@@ -52,7 +53,7 @@ By default, all remaining space on the disk will be used.
 
 By default, bootc install and install-to-filesystem assumes that it runs
 in a podman container, and it takes the container image to install from
-the podman's container registry. If \--source-imgref is given, bootc uses
+the podmans container registry. If \--source-imgref is given, bootc uses
 it as the installation source, instead of the behaviour explained in the
 previous paragraph. See skopeo(1) for accepted formats.
 
@@ -77,7 +78,7 @@ previous paragraph. See skopeo(1) for accepted formats.
 
 **\--skip-fetch-check**
 
-:   By default, the accessibility of the target image will be verified
+:   By default, the accessiblity of the target image will be verified
     (just the manifest will be fetched). Specifying this option
     suppresses the check; use this when you know the issues it might
     find are addressed.
@@ -96,6 +97,18 @@ disabled but where the target does have SELinux enabled.
 **\--karg**=*KARG*
 
 :   Add a kernel argument
+
+**\--root-ssh-authorized-keys**=*ROOT_SSH_AUTHORIZED_KEYS*
+
+:   The path to an \`authorized_keys\` that will be injected into the
+    \`root\` account.
+
+The implementation of this uses systemd \`tmpfiles.d\`, writing to a
+file named \`/etc/tmpfiles.d/bootc-root-ssh.conf\`. This will have the
+effect that by default, the SSH credentials will be set if not present.
+The intention behind this is to allow mounting the whole \`/root\` home
+directory as a \`tmpfs\`, while still getting the SSH key replaced on
+boot.
 
 **\--generic-image**
 

--- a/manpages-md/bootc-install-to-filesystem.md
+++ b/manpages-md/bootc-install-to-filesystem.md
@@ -5,11 +5,11 @@ bootc-install-to-filesystem - Install to the target filesystem
 # SYNOPSIS
 
 **bootc-install-to-filesystem** \[**\--root-mount-spec**\]
-\[**\--root-options**\] \[**\--boot-mount-spec**\] \[**\--replace**\]
-\[**\--source-imgref**\] \[**\--target-transport**\]
-\[**\--target-imgref**\] \[**\--enforce-container-sigpolicy**\]
-\[**\--target-ostree-remote**\] \[**\--skip-fetch-check**\]
-\[**\--disable-selinux**\] \[**\--karg**\] \[**\--generic-image**\]
+\[**\--boot-mount-spec**\] \[**\--replace**\] \[**\--source-imgref**\]
+\[**\--target-transport**\] \[**\--target-imgref**\]
+\[**\--enforce-container-sigpolicy**\] \[**\--target-ostree-remote**\]
+\[**\--skip-fetch-check**\] \[**\--disable-selinux**\] \[**\--karg**\]
+\[**\--root-ssh-authorized-keys**\] \[**\--generic-image**\]
 \[**-h**\|**\--help**\] \[**-V**\|**\--version**\] \<*ROOT_PATH*\>
 
 # DESCRIPTION
@@ -22,11 +22,6 @@ Install to the target filesystem
 
 :   Source device specification for the root filesystem. For example,
     UUID=2e9f4241-229b-4202-8429-62d2302382e1
-
-**\--root-options**=*ROOT_OPTIONS*
-
-:   Comma-separated mount options for the root filesystem. For example:
-    rw,prjquota
 
 **\--boot-mount-spec**=*BOOT_MOUNT_SPEC*
 
@@ -60,7 +55,7 @@ be used.
 
 By default, bootc install and install-to-filesystem assumes that it runs
 in a podman container, and it takes the container image to install from
-the podman's container registry. If \--source-imgref is given, bootc uses
+the podmans container registry. If \--source-imgref is given, bootc uses
 it as the installation source, instead of the behaviour explained in the
 previous paragraph. See skopeo(1) for accepted formats.
 
@@ -85,7 +80,7 @@ previous paragraph. See skopeo(1) for accepted formats.
 
 **\--skip-fetch-check**
 
-:   By default, the accessibility of the target image will be verified
+:   By default, the accessiblity of the target image will be verified
     (just the manifest will be fetched). Specifying this option
     suppresses the check; use this when you know the issues it might
     find are addressed.
@@ -104,6 +99,18 @@ disabled but where the target does have SELinux enabled.
 **\--karg**=*KARG*
 
 :   Add a kernel argument
+
+**\--root-ssh-authorized-keys**=*ROOT_SSH_AUTHORIZED_KEYS*
+
+:   The path to an \`authorized_keys\` that will be injected into the
+    \`root\` account.
+
+The implementation of this uses systemd \`tmpfiles.d\`, writing to a
+file named \`/etc/tmpfiles.d/bootc-root-ssh.conf\`. This will have the
+effect that by default, the SSH credentials will be set if not present.
+The intention behind this is to allow mounting the whole \`/root\` home
+directory as a \`tmpfs\`, while still getting the SSH key replaced on
+boot.
 
 **\--generic-image**
 


### PR DESCRIPTION
install: Drop unimplemented root_options

I added this in 8078700c433b41ae80564def5190cdbe08315108
but it was never implemented.

Drop it to avoid confusion.

Signed-off-by: Colin Walters <walters@verbum.org>

---

manpages-md: Regenerate

(TODO: add a periodic GH action that does this)

Signed-off-by: Colin Walters <walters@verbum.org>

---

