### PR TITLE
xtask: Fixes for `cargo xtask package`

### DIFF
--- a/contrib/packaging/bootc.spec
+++ b/contrib/packaging/bootc.spec
@@ -7,8 +7,8 @@ Summary:        Boot containers
 
 License:        ASL 2.0
 URL:            https://github.com/containers/bootc
-Source0:        https://github.com/containers/bootc/releases/download/v%{version}/bootc-%{version}.tar.zst
-Source1:        https://github.com/containers/bootc/releases/download/v%{version}/bootc-%{version}-vendor.tar.zst
+Source0:        https://github.com/containers/bootc/releases/download/v%{version}/bootc-%{version}.tar.zstd
+Source1:        https://github.com/containers/bootc/releases/download/v%{version}/bootc-%{version}-vendor.tar.zstd
 
 BuildRequires: make
 BuildRequires: openssl-devel


### PR DESCRIPTION
The release process has drifted with xtask; I forget exactly why but I ended up with `.zstd`, not `.zst` in the tarballs and I've been hand-hacking that manually.

Fix things up so that `cargo xtask package` generates the source snapshot and the vendor tarball named exactly how we release them now.