### PR TITLE
renovate: Attempt to group GHA updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -48,6 +48,13 @@
 
   "packageRules": [
     {
+      "groupName": "all github action dependencies",
+      "groupSlug": "all-github-action",
+      "matchPaths": [
+        ".github/workflows/**"
+      ],
+    },
+    {
       "groupName": "all patch dependencies",
       "groupSlug": "all-patch",
       "matchPackagePatterns": [


### PR DESCRIPTION
It will never work to try to bump e.g. the upload and download actions as separate PRs.