### PR TITLE
tests: Another missing `assert!` change to dump stderr

### DIFF
--- a/lib/src/privtests.rs
+++ b/lib/src/privtests.rs
@@ -100,7 +100,10 @@ pub(crate) fn impl_run_container() -> Result<()> {
         .output()?;
     assert!(!o.status.success());
     let stderr = String::from_utf8(o.stderr)?;
-    assert!(stderr.contains("requires root privileges"));
+    assert!(
+        stderr.contains("requires root privileges"),
+        "stderr: {stderr}"
+    );
 
     let config = cmd!(sh, "bootc install print-configuration").read()?;
     let mut config: InstallConfiguration =


### PR DESCRIPTION
I missed that there were two here; followup to previous commit.