### PR TITLE
spec: %autorelease can't be resolved by COPR

### DIFF
--- a/contrib/packaging/bootc.spec
+++ b/contrib/packaging/bootc.spec
@@ -2,7 +2,7 @@
 
 Name:           bootc
 Version:        0.1
-Release:        %autorelease
+Release:        1%{?dist}
 Summary:        Boot containers
 
 License:        ASL 2.0


### PR DESCRIPTION
COPR can't resolve `%autorelease`. That caused bootc RPM pakcage name like `bootc-202403011229.g5dde9d8842-%autorelease.x86_64`.
This PR uses `1%{?dist}` instead.