### PR TITLE
blockdev: Use --direct-io=on for losetup

### DIFF
--- a/lib/src/blockdev.rs
+++ b/lib/src/blockdev.rs
@@ -84,7 +84,7 @@ impl LoopbackDevice {
     // Create a new loopback block device targeting the provided file path.
     pub(crate) fn new(path: &Path) -> Result<Self> {
         let dev = Task::new("losetup", "losetup")
-            .args(["--show", "-P", "--find"])
+            .args(["--show", "--direct-io=on", "-P", "--find"])
             .arg(path)
             .quiet()
             .read()?;


### PR DESCRIPTION
This is what other projects do; it avoids double buffering and is generally a good idea.