### PR TITLE
test: update integration README

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -79,8 +79,6 @@ jobs:
           git_ref: ${{ needs.pr-info.outputs.ref }}
           arch: ${{ matrix.arch }}
           tmt_context: "arch=${{ matrix.arch }}"
-          update_pull_request_status: true
-          pull_request_status_name: "Integration-rhel94-${{ matrix.arch }}-${{ matrix.platform }}"
           tmt_plan_regex: "${{ matrix.platform }}"
           tf_scope: private
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};QUAY_SECRET=${{ secrets.QUAY_SECRET }};RHEL_REGISTRY_URL=${{ secrets.RHEL_REGISTRY_URL }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }};AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }};AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}"
@@ -112,8 +110,6 @@ jobs:
           git_ref: ${{ needs.pr-info.outputs.ref }}
           arch: ${{ matrix.arch }}
           tmt_context: "arch=${{ matrix.arch }}"
-          update_pull_request_status: true
-          pull_request_status_name: "Integration-cs9-dev-${{ matrix.arch }}-${{ matrix.platform }}"
           tmt_plan_regex: "${{ matrix.platform }}"
           tf_scope: private
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};QUAY_SECRET=${{ secrets.QUAY_SECRET }};AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }};AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}"

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -30,7 +30,6 @@ Run `testing-farm` CLI from `quay.io/testing-farm/cli` container. Don't forget e
         --environment AWS_REGION=us-east-1 \
         --secret DOWNLOAD_NODE=$DOWNLOAD_NODE \
         --secret RHEL_REGISTRY_URL=$RHEL_REGISTRY_URL \
-        --secret CERT_URL=$CERT_URL \
         --secret QUAY_USERNAME=$QUAY_USERNAME \
         --secret QUAY_PASSWORD=$QUAY_PASSWORD \
         --secret QUAY_SECRET=$QUAY_SECRET \
@@ -62,7 +61,6 @@ Run `testing-farm` CLI from `quay.io/testing-farm/cli` container. Don't forget e
     QUAY_SECRET        Save into /etc/ostree/auth.json for authenticated registry
     DOWNLOAD_NODE      RHEL nightly compose download URL
     RHEL_REGISTRY_URL  RHEL bootc image URL
-    CERT_URL           CA certificate download URL
     AWS_ACCESS_KEY_ID           AWS access key id
     AWS_SECRET_ACCESS_KEY       AWS secrety key
     AWS_REGION                  AWS region

--- a/tests/integration/install-upgrade.fmf
+++ b/tests/integration/install-upgrade.fmf
@@ -6,4 +6,4 @@
 /bootc-install-upgrade:
   summary: bootc install and upgrade test
   test: ./install-upgrade.sh
-  duration: 40m
+  duration: 90m

--- a/tests/integration/playbooks/install.yaml
+++ b/tests/integration/playbooks/install.yaml
@@ -54,6 +54,14 @@
       no_log: true
       become: true
 
+    - name: Pull image
+      command: "podman pull {{ test_image_url }}"
+      become: true
+      retries: 3
+      delay: 10
+      register: result
+      until: result is successful
+
     - name: Install image
       command:
         "podman run \


### PR DESCRIPTION
Use `--tls-verify=false` in podman build, don't need CERT_URL secret any more.