### PR TITLE
cli: add container lint

### DIFF
--- a/docs/src/man/bootc-container-lint.md
+++ b/docs/src/man/bootc-container-lint.md
@@ -1,0 +1,23 @@
+# NAME
+
+bootc-container-lint - Perform relatively inexpensive static analysis
+checks as part of a container build
+
+# SYNOPSIS
+
+**bootc container lint** \[**-h**\|**\--help**\]
+
+# DESCRIPTION
+
+Perform relatively inexpensive static analysis checks as part of a
+container build
+
+# OPTIONS
+
+**-h**, **\--help**
+
+:   Print help
+
+# VERSION
+
+v0.1.11

--- a/docs/src/man/bootc-container.md
+++ b/docs/src/man/bootc-container.md
@@ -1,0 +1,33 @@
+# NAME
+
+bootc-container - Operations which can be executed as part of a
+container build
+
+# SYNOPSIS
+
+**bootc container** \[**-h**\|**\--help**\] \<*subcommands*\>
+
+# DESCRIPTION
+
+Operations which can be executed as part of a container build
+
+# OPTIONS
+
+**-h**, **\--help**
+
+:   Print help
+
+# SUBCOMMANDS
+
+bootc-container-lint(8)
+
+:   Perform relatively inexpensive static analysis checks as part of a
+    container build
+
+bootc-container-help(8)
+
+:   Print this message or the help of the given subcommand(s)
+
+# VERSION
+
+v0.1.11

--- a/docs/src/man/bootc.md
+++ b/docs/src/man/bootc.md
@@ -62,6 +62,10 @@ bootc-install(8)
 
 :   Install the running container to a target
 
+bootc-container(8)
+
+:   Operations which can be executed as part of a container build
+
 bootc-help(8)
 
 :   Print this message or the help of the given subcommand(s)

--- a/hack/Containerfile
+++ b/hack/Containerfile
@@ -16,3 +16,4 @@ FROM $base
 COPY --from=build /out/bootc.tar.zst /tmp
 COPY --from=build /build/target/dev-rootfs/ /
 RUN tar -C / --zstd -xvf /tmp/bootc.tar.zst && rm -vf /tmp/*
+RUN bootc container lint

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -21,6 +21,7 @@ pub mod cli;
 pub(crate) mod deploy;
 pub(crate) mod generator;
 pub(crate) mod journal;
+mod lints;
 mod lsm;
 pub(crate) mod metadata;
 mod reboot;

--- a/lib/src/lints.rs
+++ b/lib/src/lints.rs
@@ -1,0 +1,72 @@
+//! # Implementation of container build lints
+//!
+//! This module implements `bootc container lint`.
+
+use anyhow::Result;
+use cap_std::fs::Dir;
+use cap_std_ext::cap_std;
+use cap_std_ext::dirext::CapStdExtDirExt as _;
+use fn_error_context::context;
+
+/// check for the existence of the /var/run directory
+/// if it exists we need to check that it links to /run if not error
+/// if it does not exist error.
+#[context("Linting")]
+pub(crate) fn lint(root: &Dir) -> Result<()> {
+    let lints = [check_var_run, check_kernel];
+    for lint in lints {
+        lint(&root)?;
+    }
+    println!("Checks passed: {}", lints.len());
+    Ok(())
+}
+
+fn check_var_run(root: &Dir) -> Result<()> {
+    if let Some(meta) = root.symlink_metadata_optional("var/run")? {
+        if !meta.is_symlink() {
+            anyhow::bail!("Not a symlink: var/run");
+        }
+    }
+    Ok(())
+}
+
+fn check_kernel(root: &Dir) -> Result<()> {
+    let result = ostree_ext::bootabletree::find_kernel_dir_fs(&root)?;
+    tracing::debug!("Found kernel: {:?}", result);
+    Ok(())
+}
+
+#[cfg(test)]
+fn fixture() -> Result<cap_std_ext::cap_tempfile::TempDir> {
+    let tempdir = cap_std_ext::cap_tempfile::tempdir(cap_std::ambient_authority())?;
+    Ok(tempdir)
+}
+
+#[test]
+fn test_var_run() -> Result<()> {
+    let root = &fixture()?;
+    // This one should pass
+    check_var_run(root).unwrap();
+    root.create_dir_all("var/run/foo")?;
+    assert!(check_var_run(root).is_err());
+    root.remove_dir_all("var/run")?;
+    // Now we should pass again
+    check_var_run(root).unwrap();
+    Ok(())
+}
+
+#[test]
+fn test_kernel_lint() -> Result<()> {
+    let root = &fixture()?;
+    // This one should pass
+    check_kernel(root).unwrap();
+    root.create_dir_all("usr/lib/modules/5.7.2")?;
+    root.write("usr/lib/modules/5.7.2/vmlinuz", "old vmlinuz")?;
+    root.create_dir_all("usr/lib/modules/6.3.1")?;
+    root.write("usr/lib/modules/6.3.1/vmlinuz", "new vmlinuz")?;
+    assert!(check_kernel(root).is_err());
+    root.remove_dir_all("usr/lib/modules/5.7.2")?;
+    // Now we should pass again
+    check_kernel(root).unwrap();
+    Ok(())
+}


### PR DESCRIPTION
Add an entrypoint that basically everyone can start
adding to their builds which performs some basic
static analysis for known problems.

---

(original description follows)


We know this does not fix #216 yet, we are working this in time-slots as a part of mobbing to address this. In the next update we plan on having the logic to check for one kernel complete. Then we can debate if we want the lint to be in this code base, or if we want it to be moved somewhere else. 
