### PR TITLE
install: Support gathering more info for host root (including LVM)

### DIFF
--- a/docs/src/bootc-install.md
+++ b/docs/src/bootc-install.md
@@ -238,7 +238,7 @@ support the root storage setup already initialized.
 The core command should look like this (root/elevated permission required):
 
 ```bash
-podman run --rm --privileged -v /var/lib/containers:/var/lib/containers -v /:/target \
+podman run --rm --privileged -v /dev:/dev -v /var/lib/containers:/var/lib/containers -v /:/target \
              --pid=host --security-opt label=type:unconfined_t \
              <image> \
              bootc install to-existing-root

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -533,7 +533,9 @@ async fn run_from_opt(opt: Opt) -> Result<()> {
         #[cfg(feature = "install")]
         Opt::Install(opts) => match opts {
             InstallOpts::ToDisk(opts) => crate::install::install_to_disk(opts).await,
-            InstallOpts::ToFilesystem(opts) => crate::install::install_to_filesystem(opts).await,
+            InstallOpts::ToFilesystem(opts) => {
+                crate::install::install_to_filesystem(opts, false).await
+            }
             InstallOpts::ToExistingRoot(opts) => {
                 crate::install::install_to_existing_root(opts).await
             }

--- a/lib/src/kernel.rs
+++ b/lib/src/kernel.rs
@@ -1,0 +1,46 @@
+use anyhow::Result;
+use fn_error_context::context;
+
+/// This is used by dracut.
+pub(crate) const INITRD_ARG_PREFIX: &str = "rd.";
+/// The kernel argument for configuring the rootfs flags.
+pub(crate) const ROOTFLAGS: &str = "rootflags=";
+
+/// Parse the kernel command line.  This is strictly
+/// speaking not a correct parser, as the Linux kernel
+/// supports quotes.  However, we don't yet need that here.
+///
+/// See systemd's code for one userspace parser.
+#[context("Reading /proc/cmdline")]
+pub(crate) fn parse_cmdline() -> Result<Vec<String>> {
+    let cmdline = std::fs::read_to_string("/proc/cmdline")?;
+    let r = cmdline
+        .split_ascii_whitespace()
+        .map(ToOwned::to_owned)
+        .collect();
+    Ok(r)
+}
+
+/// Return the value for the string in the vector which has the form target_key=value
+pub(crate) fn find_first_cmdline_arg<'a>(
+    args: impl Iterator<Item = &'a str>,
+    target_key: &str,
+) -> Option<&'a str> {
+    args.filter_map(|arg| {
+        if let Some((k, v)) = arg.split_once('=') {
+            if target_key == k {
+                return Some(v);
+            }
+        }
+        None
+    })
+    .next()
+}
+
+#[test]
+fn test_find_first() {
+    let kargs = &["foo=bar", "root=/dev/vda", "blah", "root=/dev/other"];
+    let kargs = || kargs.iter().map(|&s| s);
+    assert_eq!(find_first_cmdline_arg(kargs(), "root"), Some("/dev/vda"));
+    assert_eq!(find_first_cmdline_arg(kargs(), "nonexistent"), None);
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -41,6 +41,8 @@ mod containerenv;
 mod install;
 mod k8sapitypes;
 #[cfg(feature = "install")]
+mod kernel;
+#[cfg(feature = "install")]
 pub(crate) mod mount;
 #[cfg(feature = "install")]
 mod podman;


### PR DESCRIPTION
Builds on top of https://github.com/containers/bootc/pull/382
---

install: Support gathering more info for host root (including LVM)

Teach `install to-existing-root` how to gather kernel arguments
and information we need from `/proc/cmdline` (such as `rd.lvm.lv`).
In this case too, we need to adjust the args to use `-v /dev:/dev`
because we need the stuff udev generates from the real host root.

With these things together, I can do a bootc alongside install
targeting a Fedora Server instance.

Closes: https://github.com/containers/bootc/issues/175
Signed-off-by: Colin Walters <walters@verbum.org>

---

