### PR TITLE
install: Improve early output

### DIFF
--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -849,11 +849,10 @@ pub(crate) fn setup_tmp_mounts() -> Result<()> {
     } else {
         // Note we explicitly also don't want a "nosuid" tmp, because that
         // suppresses our install_t transition
-        Task::new_and_run(
-            "Mounting tmpfs /tmp",
-            "mount",
-            ["tmpfs", "-t", "tmpfs", "/tmp"],
-        )?;
+        Task::new("Mounting tmpfs /tmp", "mount")
+            .args(["tmpfs", "-t", "tmpfs", "/tmp"])
+            .quiet()
+            .run()?;
     }
 
     // Point our /var/tmp at the host, via the /proc/1/root magic link
@@ -918,11 +917,10 @@ pub(crate) fn setup_sys_mount(fstype: &str, fspath: &str) -> Result<()> {
     }
 
     // This means the host has this mounted, so we should mount it too
-    Task::new_and_run(
-        format!("Mounting {fstype} {fspath}"),
-        "mount",
-        ["-t", fstype, fstype, fspath],
-    )
+    Task::new(format!("Mounting {fstype} {fspath}"), "mount")
+        .args(["-t", fstype, fstype, fspath])
+        .quiet()
+        .run()
 }
 
 /// Verify that we can load the manifest of the target image
@@ -1025,6 +1023,8 @@ async fn prepare_install(
     // Now, deal with SELinux state.
     let (override_disable_selinux, setenforce_guard) =
         reexecute_self_for_selinux_if_needed(&source, config_opts.disable_selinux)?;
+
+    println!("Installing: {:#}", &target_imgref);
 
     let install_config = config::load_config()?;
     tracing::debug!("Loaded install configuration");

--- a/lib/src/install/baseline.rs
+++ b/lib/src/install/baseline.rs
@@ -175,11 +175,10 @@ pub(crate) fn install_create_rootfs(
     }
     let devdir = mntdir.join("dev");
     std::fs::create_dir_all(&devdir)?;
-    Task::new_and_run(
-        "Mounting devtmpfs",
-        "mount",
-        ["devtmpfs", "-t", "devtmpfs", devdir.as_str()],
-    )?;
+    Task::new("Mounting devtmpfs", "mount")
+        .args(["devtmpfs", "-t", "devtmpfs", devdir.as_str()])
+        .quiet()
+        .run()?;
 
     // Now at this point, our /dev is a stale snapshot because we don't have udev running.
     // So from hereon after, we prefix devices with our temporary devtmpfs mount.


### PR DESCRIPTION
The mount output for tmpfs/etc. is just an implementation detail, we don't need to print it.  Do add a log message with the container information to make more clear
that's what's going on - we're installing the running container image.