### PR TITLE
More image output cleanup

### DIFF
--- a/lib/src/deploy.rs
+++ b/lib/src/deploy.rs
@@ -265,7 +265,7 @@ pub(crate) async fn stage(
     )
     .await?;
     crate::deploy::cleanup(sysroot).await?;
-    println!("Queued for next boot: {}", spec.image);
+    println!("Queued for next boot: {:#}", spec.image);
     if let Some(version) = image.version.as_deref() {
         println!("  Version: {version}");
     }

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -610,13 +610,10 @@ async fn initialize_ostree_root_from_self(
     options.kargs = Some(kargs.as_slice());
     options.target_imgref = Some(&state.target_imgref);
     options.proxy_cfg = proxy_cfg;
-    println!("Creating initial deployment");
-    let target_image = state.target_imgref.to_string();
+    println!("Deploying container image");
     let imgstate =
         ostree_container::deploy::deploy(&sysroot, stateroot, &src_imageref, Some(options)).await?;
-    let digest = imgstate.manifest_digest.as_str();
-    println!("Installed: {target_image}");
-    println!("   Digest: {digest}");
+    println!("Deployment complete");
 
     // Write the entry for /boot to /etc/fstab.  TODO: Encourage OSes to use the karg?
     // Or better bind this with the grub data.
@@ -1031,7 +1028,10 @@ async fn prepare_install(
     let (override_disable_selinux, setenforce_guard) =
         reexecute_self_for_selinux_if_needed(&source, config_opts.disable_selinux)?;
 
-    println!("Installing: {:#}", &target_imgref);
+    println!("Installing image: {:#}", &target_imgref);
+    if let Some(digest) = source.digest.as_deref() {
+        println!("Digest: {digest}");
+    }
 
     let install_config = config::load_config()?;
     tracing::debug!("Loaded install configuration");


### PR DESCRIPTION
deploy: Use alternative format for staging

Followup to e3db0108b194f420c014bdcbce0c3e705f3942f6
where this one was missed.  Copy-pasting that git log
for ease of consumption:

Same motivation as https://github.com/ostreedev/ostree-rs-ext/pull/604

Because fetching from a registry with the default sigverify is
the 90% case default, when we see this (and are formatting for
human consumption), use the "alternate" formatting to just
display the image name.

This makes the ostree stuff *much* less in the user's face
in the default path.

Signed-off-by: Colin Walters <walters@verbum.org>

---

install: Clean up image output more

Ensure we use alternative formatting for the image reference
for consistency.

And move the image output (including digest) to the very
start where it's more centralized.

Signed-off-by: Colin Walters <walters@verbum.org>

---

