### PR TITLE
lsm/install: Use csum(), not name() from SELinux policy

### DIFF
--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -309,7 +309,10 @@ impl State {
         // We always use the physical container root to bootstrap policy
         let rootfs = &Dir::open_ambient_dir("/", cap_std::ambient_authority())?;
         let r = ostree::SePolicy::new_at(rootfs.as_raw_fd(), gio::Cancellable::NONE)?;
-        tracing::debug!("Loaded SELinux policy: {}", r.name());
+        let csum = r
+            .csum()
+            .ok_or_else(|| anyhow::anyhow!("SELinux enabled, but no policy found in root"))?;
+        tracing::debug!("Loaded SELinux policy: {csum}");
         Ok(Some(r))
     }
 }

--- a/lib/src/lsm.rs
+++ b/lib/src/lsm.rs
@@ -175,8 +175,8 @@ pub(crate) fn require_label(
         .label(destname.as_str(), mode, ostree::gio::Cancellable::NONE)?
         .ok_or_else(|| {
             anyhow::anyhow!(
-                "No label found in policy '{}' for {destname})",
-                policy.name()
+                "No label found in policy '{:?}' for {destname})",
+                policy.csum()
             )
         })
 }


### PR DESCRIPTION
There's a bug in the ostree API here around nullability.

Closes https://github.com/containers/bootc/issues/403