### PR TITLE
install: Add some more debug/trace calls

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -286,6 +286,7 @@ pub(crate) fn require_root() -> Result<()> {
     if !rustix::thread::capability_is_in_bounding_set(rustix::thread::Capability::SystemAdmin)? {
         anyhow::bail!("This command requires full root privileges (CAP_SYS_ADMIN)");
     }
+    tracing::trace!("Verified uid 0 with CAP_SYS_ADMIN");
     Ok(())
 }
 

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -436,6 +436,7 @@ impl SourceInfo {
             transport: ostree_container::Transport::ContainerStorage,
             name: container_info.image.clone(),
         };
+        tracing::debug!("Finding digest for image ID {}", container_info.imageid);
         let digest = crate::podman::imageid_to_digest(&container_info.imageid)?;
 
         let root = Dir::open_ambient_dir("/", cap_std::ambient_authority())?;
@@ -848,6 +849,7 @@ fn require_host_pidns() -> Result<()> {
     if rustix::process::getpid().is_init() {
         anyhow::bail!("This command must be run with --pid=host")
     }
+    tracing::trace!("OK: we're not pid 1");
     Ok(())
 }
 
@@ -975,6 +977,7 @@ async fn prepare_install(
     source_opts: InstallSourceOpts,
     target_opts: InstallTargetOpts,
 ) -> Result<Arc<State>> {
+    tracing::trace!("Preparing install");
     // We need full root privileges, i.e. --privileged in podman
     crate::cli::require_root()?;
     require_host_pidns()?;
@@ -996,6 +999,7 @@ async fn prepare_install(
                     "Cannot install from rootless podman; this command must be run as root"
                 );
             }
+            tracing::trace!("Read container engine info {:?}", container_info.engine);
 
             SourceInfo::from_container(&container_info)?
         }


### PR DESCRIPTION
John is hitting an issue where we're failing to re-exec into the mount namespace when querying podman for some reason.  We log surprisingly little even at trace level before we get there. I don't think this will help debug it, but I had to carefully read the code to know that e.g. we've verified we're not running under rootless podman until the time we get there.

More logging especially at trace level is ~free so let's do it.