### PR TITLE
Correctly populate container environment rootless status

### DIFF
--- a/lib/src/containerenv.rs
+++ b/lib/src/containerenv.rs
@@ -48,6 +48,7 @@ pub(crate) fn get_container_execution_info(rootfs: &Dir) -> Result<ContainerExec
             "id" => r.id = v.to_string(),
             "image" => r.image = v.to_string(),
             "imageid" => r.imageid = v.to_string(),
+            "rootless" => r.rootless = Some(v.to_string()),
             _ => {}
         }
     }

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -1003,7 +1003,7 @@ async fn prepare_install(
                     "Cannot install from rootless podman; this command must be run as root"
                 );
             }
-            tracing::trace!("Read container engine info {:?}", container_info.engine);
+            tracing::trace!("Read container engine info {:?}", container_info);
 
             SourceInfo::from_container(&container_info)?
         }


### PR DESCRIPTION
Previously this was just always None via Default.

Also updated trace logging to show the entire container_info struct.
All of those fields are potentially useful, not just engine.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
