### PR TITLE
Trace rootless

### DIFF
--- a/lib/src/containerenv.rs
+++ b/lib/src/containerenv.rs
@@ -48,6 +48,7 @@ pub(crate) fn get_container_execution_info(rootfs: &Dir) -> Result<ContainerExec
             "id" => r.id = v.to_string(),
             "image" => r.image = v.to_string(),
             "imageid" => r.imageid = v.to_string(),
+            "rootless" => r.rootless = Some(v.to_string()),
             _ => {}
         }
     }

--- a/lib/src/containerenv.rs
+++ b/lib/src/containerenv.rs
@@ -8,7 +8,7 @@ use cap_std_ext::prelude::CapStdExtDirExt;
 use fn_error_context::context;
 
 /// Path is relative to container rootfs (assumed to be /)
-const PATH: &str = "run/.containerenv";
+pub(crate) const PATH: &str = "run/.containerenv";
 
 #[derive(Debug, Default)]
 pub(crate) struct ContainerExecutionInfo {

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -1003,7 +1003,7 @@ async fn prepare_install(
                     "Cannot install from rootless podman; this command must be run as root"
                 );
             }
-            tracing::trace!("Read container engine info {:?}", container_info.engine);
+            tracing::trace!("Read container engine info {:?}", container_info);
 
             SourceInfo::from_container(&container_info)?
         }


### PR DESCRIPTION
This builds on https://github.com/containers/bootc/pull/413

---

This will catch rootless podman cases even more reliably (assuming
we were invoked with `--pid=host`).
