### PR TITLE
feat(build): Add extra version information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "bootc"
-version = "0.1.0"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "bootc-lib",
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "bootc-lib"
-version = "0.1.0"
+version = "0.1.9"
 dependencies = [
  "anstream",
  "anstyle",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bootc"
-version = "0.1.0"
+version = "0.1.9"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cgwalters/bootc"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -5,8 +5,9 @@ license = "MIT OR Apache-2.0"
 name = "bootc-lib"
 readme = "README.md"
 repository = "https://github.com/cgwalters/bootc"
-version = "0.1.0"
+version = "0.1.9"
 rust-version = "1.64.0"
+build = "build.rs"
 
 include = ["/src", "LICENSE-APACHE", "LICENSE-MIT"]
 
@@ -17,7 +18,7 @@ anyhow = "1.0"
 camino = { version = "1.1.6", features = ["serde1"] }
 ostree-ext = { version = "0.13.3"  }
 chrono = { version = "0.4.35", features = ["serde"] }
-clap = { version= "4.5", features = ["derive"] }
+clap = { version= "4.5", features = ["derive","cargo"] }
 clap_mangen = { version = "0.2", optional = true }
 cap-std-ext = "4"
 hex = "^0.4.3"

--- a/lib/build.rs
+++ b/lib/build.rs
@@ -1,0 +1,22 @@
+// build.rs
+
+use std::env;
+use std::fs;
+use std::path::Path;
+
+fn main() {
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let dest_path = Path::new(&out_dir).join("version.rs");
+    fs::write(
+        &dest_path,
+        "
+         #[allow(dead_code)]
+         #[allow(clippy::all)]
+         use clap::crate_version;
+         #[doc=r#\"Version string\"#]
+         pub const CLAP_LONG_VERSION: &str = crate_version!();
+        ",
+    )
+    .unwrap();
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -22,6 +22,8 @@ use crate::spec::Host;
 use crate::spec::ImageReference;
 use crate::utils::sigpolicy_from_opts;
 
+include!(concat!(env!("OUT_DIR"), "/version.rs"));
+
 /// Perform an upgrade operation
 #[derive(Debug, Parser)]
 pub(crate) struct UpgradeOpts {
@@ -171,6 +173,7 @@ pub(crate) enum TestingOpts {
 #[derive(Debug, Parser)]
 #[clap(name = "bootc")]
 #[clap(rename_all = "kebab-case")]
+#[clap(version,long_version=CLAP_LONG_VERSION)]
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum Opt {
     /// Download and queue an updated container image to apply.


### PR DESCRIPTION
Simple build-time code generation for now. Plan to add git info from the environment if it exists.

Fixes #361