### PR TITLE
install: Change no-SELinux -> SELinux to a warning && serialize to aleph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,6 @@ jobs:
           # TODO fix https://github.com/containers/bootc/pull/137
           sudo chattr -i /ostree/deploy/default/deploy/*
           sudo rm /ostree/deploy/default -rf
-          sudo podman run --rm -ti --privileged --env BOOTC_SKIP_SELINUX_HOST_CHECK=1 --env RUST_LOG=debug -v /:/target -v /var/lib/containers:/var/lib/containers -v ./usr/bin/bootc:/usr/bin/bootc --pid=host --security-opt label=disable \
+          sudo podman run --rm -ti --privileged --env RUST_LOG=debug -v /:/target -v /var/lib/containers:/var/lib/containers -v ./usr/bin/bootc:/usr/bin/bootc --pid=host --security-opt label=disable \
             ${image} bootc install to-existing-root
           sudo podman run --rm -ti --privileged -v /:/target -v ./usr/bin/bootc:/usr/bin/bootc --pid=host --security-opt label=disable ${image} bootc internal-tests verify-selinux /target/ostree --warn


### PR DESCRIPTION
install: Change no-SELinux -> SELinux to a warning

We believe we have almost all the labeling work here covered,
so degrade this to a warning.

Signed-off-by: Colin Walters <walters@verbum.org>

---

install: Change SELinux state into enum, serialize to aleph

We want to support the "installing SELinux target from SELinux-disabled
host" - but in case we run into problems, let's serialize the state
of things at install time into the aleph data, for the same reason
we save other relevant environmental data like the kernel version.

Signed-off-by: Colin Walters <walters@verbum.org>

---

