### PR TITLE
Stop if /dev is not a bind mount with loopback

### DIFF
--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -1177,6 +1177,9 @@ pub(crate) async fn install_to_disk(mut opts: InstallToDiskOpts) -> Result<()> {
                 block_opts.device
             );
         }
+        if !crate::mount::is_same_as_host(Utf8Path::new("/dev"))? {
+            anyhow::bail!("Loopback mounts (--via-loopback) require host devices (-v /dev:/dev)");
+        }
     } else if !target_blockdev_meta.file_type().is_block_device() {
         anyhow::bail!("Not a block device: {}", block_opts.device);
     }


### PR DESCRIPTION
At container start, /dev is snapshotted, so any new device files
don't get added unless /dev is bindmounted in. For now, check that
/dev is the same as the host's /dev via fsid. If they differ, it
means that /dev is not bindmounted.

Fixes #352

