### PR TITLE
Add constraint on rust 1.76

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -73,6 +73,8 @@
   // Don't leave dep. update. PRs "hanging", assign them to people.
   // "assignees": ["containers/netavark-maintainers"],
 
+  "constraints": {"rust": "1.76"},
+
   /**************************************************
    ***** Manager-specific configuration options *****
    **************************************************/


### PR DESCRIPTION
Renovate can't install 1.77 for some reason, and I'm not sure if it
can't install *any* version, or if something is just broken with 1.77
since it's relatively new.  So let's try 1.76 and see what happens.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
