### PR TITLE
Revert "fix(deps): update all patch dependencies"

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -32,13 +32,13 @@ once_cell = "1.19"
 openssl = "^0.10.64"
 # TODO drop this in favor of rustix
 nix = { version = "0.28", features = ["ioctl", "sched"] }
-regex = "1.10.4"
+regex = "1.10.3"
 rustix = { "version" = "0.38", features = ["thread", "fs", "system", "process"] }
 schemars = { version = "0.8.16", features = ["chrono"] }
 serde = { features = ["derive"], version = "1.0.197" }
 serde_ignored = "0.1.10"
 serde_json = "1.0.114"
-serde_yaml = "0.9.34"
+serde_yaml = "0.9.33"
 serde_with = ">= 3.7.0, < 4"
 tokio = { features = ["io-std", "time", "process", "rt", "net"], version = ">= 1.36.0" }
 tokio-util = { features = ["io-util"], version = "0.7" }


### PR DESCRIPTION
Reverts containers/bootc#423

This is broken and didn't update Cargo.lock, roll it back until we figure out why renovate is failing, and then we'll have renovate re-do it correctly.