### PR TITLE
install: Add `block` to config, disable tpm2-luks unless opted-in

### DIFF
--- a/docs/src/bootc-install.md
+++ b/docs/src/bootc-install.md
@@ -113,14 +113,7 @@ taking precedence.  If for example you are building a derived container image fr
 you could create a `50-myos.toml`  that sets `type = "btrfs"` which will override the
 prior setting.
 
-Other available options, also under the `[install]` section:
-
-`kargs`: This allows setting kernel arguments which apply only at the time of `bootc install`.
-This option is particularly useful when creating derived/layered images; for example, a cloud
-image may want to have its default `console=` set, in contrast with a default base image.
-The values in this field are space separated.
-
-`root-fs-type`: This value is the same as `install.filesystem.root.type`.
+For other available options, see [bootc-install-config](man/bootc-install-config.md).
 
 ## Installing an "unconfigured" image
 

--- a/docs/src/man-md/bootc-install-config.md
+++ b/docs/src/man-md/bootc-install-config.md
@@ -20,6 +20,9 @@ This is the only defined toplevel table.
 
 The `install`` section supports two subfields:
 
+- `block`: An array of supported `to-disk` backends enabled by this base container image;
+   if not specified, this will just be `direct`.  The only other supported value is `tpm2-luks`.
+   The first value specified will be the default.  To enable both, use `block = ["direct", "tpm2-luks"]`.
 - `filesystem`: See below.
 - `kargs`: An array of strings; this will be appended to the set of kernel arguments.
 

--- a/lib/src/install/config.rs
+++ b/lib/src/install/config.rs
@@ -177,8 +177,7 @@ root-fs-type = "xfs"
     let other = InstallConfigurationToplevel {
         install: Some(InstallConfiguration {
             root_fs_type: Some(Filesystem::Ext4),
-            filesystem: None,
-            kargs: None,
+            ..Default::default()
         }),
     };
     install.merge(other.install.unwrap());
@@ -206,14 +205,13 @@ kargs = ["console=ttyS0", "foo=bar"]
     assert_eq!(install.root_fs_type.unwrap(), Filesystem::Ext4);
     let other = InstallConfigurationToplevel {
         install: Some(InstallConfiguration {
-            root_fs_type: None,
-            filesystem: None,
             kargs: Some(
                 ["console=tty0", "nosmt"]
                     .into_iter()
                     .map(ToOwned::to_owned)
                     .collect(),
             ),
+            ..Default::default()
         }),
     };
     install.merge(other.install.unwrap());
@@ -245,13 +243,12 @@ type = "xfs"
     );
     let other = InstallConfigurationToplevel {
         install: Some(InstallConfiguration {
-            root_fs_type: None,
             filesystem: Some(BasicFilesystems {
                 root: Some(RootFS {
                     fstype: Some(Filesystem::Ext4),
                 }),
             }),
-            kargs: None,
+            ..Default::default()
         }),
     };
     install.merge(other.install.unwrap());


### PR DESCRIPTION
tests: Use `..Default::default()` for install config

To make adding a new field not require touching all the tests.

Signed-off-by: Colin Walters <walters@verbum.org>

---

install: Add `block` to config, disable tpm2-luks unless opted-in

This allows the container image builder more control over
`bootc install to-disk` in the installation config.  Per discussion in
https://github.com/containers/bootc/issues/421
this one definitely requires integration by the base image,
and not all of them will want it.

(Or if the do want LUKS, they may want more control over it)

The default value is `block: ["direct"]` which only enables
the simple filesystem install.

This change allows two different things:

`block: []`

With this, `bootc install to-disk` will just error out.  It's
a way to effectively disable it for those that want to use
an external installer always.

Another possibility is:

`block: ["direct", "tpm2-luks"]`

To explicitly re-enable the builtin tpm2-luks flow.

Or, one could do just `block: ["tpm2-luks"]` to enforce encrypted installs.

Signed-off-by: Colin Walters <walters@verbum.org>

---

