### PR TITLE
Add a `rollback` verb and `rollbackQueued` status

### DIFF
--- a/tests/integration/playbooks/rollback.yaml
+++ b/tests/integration/playbooks/rollback.yaml
@@ -6,8 +6,8 @@
     failed_counter: "0"
 
   tasks:
-    - name: rpm-ostree rollback
-      command: rpm-ostree rollback
+    - name: bootc rollback
+      command: bootc rollback
       become: true
 
     - name: Reboot to deploy new system


### PR DESCRIPTION
I'd really hoped to do something more declarative here, and really flesh out the intersections with automated upgrades and automated rollbacks.

But, this just exposes the simple primitive, equivalent to `rpm-ostree rollback`.