### PR TITLE
Revert "Add constraint on rust 1.76"

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -73,8 +73,6 @@
   // Don't leave dep. update. PRs "hanging", assign them to people.
   // "assignees": ["containers/netavark-maintainers"],
 
-  "constraints": {"rust": "1.76"},
-
   /**************************************************
    ***** Manager-specific configuration options *****
    **************************************************/


### PR DESCRIPTION
This reverts commit 224f91ce9cc3ad4a0147b581ca2c5254500b1850.

Renovate is still trying (and failing) to install rust 1.77 despite
this change, so let's revert it.  I think renovate has bigger problems
anyway, and it doesn't have anything to do with the particular rust
version.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
