### PR TITLE
privtests: Differentiate duplicate contexts

### DIFF
--- a/lib/src/privtests.rs
+++ b/lib/src/privtests.rs
@@ -122,7 +122,7 @@ pub(crate) fn impl_run_container() -> Result<()> {
     Ok(())
 }
 
-#[context("Container tests")]
+#[context("Prep test install filesystem")]
 fn prep_test_install_filesystem(blockdev: &Utf8Path) -> Result<tempfile::TempDir> {
     let sh = Shell::new()?;
     // Arbitrarily larger partition offsets
@@ -151,7 +151,7 @@ fn prep_test_install_filesystem(blockdev: &Utf8Path) -> Result<tempfile::TempDir
     Ok(mountpoint_dir)
 }
 
-#[context("Container tests")]
+#[context("Test install filesystem")]
 fn test_install_filesystem(image: &str, blockdev: &Utf8Path) -> Result<()> {
     let sh = Shell::new()?;
 


### PR DESCRIPTION
Was having trouble figuring out which place "Container tests" in an
error message was actually referring to.  Give these unique contexts.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
