### PR TITLE
docs/filesystem: 

### DIFF
--- a/docs/src/filesystem.md
+++ b/docs/src/filesystem.md
@@ -78,12 +78,21 @@ As of OSTree v2024.3, by default [content in /var acts like a Docker VOLUME /var
 This means that the content from the container image is copied at initial installation time, and *not updated thereafter*.
 
 Note this is very different from the handling of `/etc`.   The rationale for this is
-that `/etc` should generally only hold small text files, but `/var` should hold arbitrarily
-large data (system logs, databases, etc.).  Creating multiple copies of it would have
+that `/etc` is relatively small configuration files, and the expected configuration
+files are often bound to the operating system binaries in `/usr`.
 
-to keep operating system upgrades from touching machine-local data by default.
-If the system is rolled back to a previous bootloader entry, the `/var` content remains.  This also
-makes it possible to "stage" new operating system updates in an alternative root without affecting `/var` content.
+But `/var` has arbitrarily large data (system logs, databases, etc.).  It would
+also not be expected to be rolled back if the operating system state is rolled
+back.  A simple exmaple is that an `apt|dnf downgrade postgresql` should not
+affect the physical database in general in `/var/lib/postgres`.  Similarly,
+a bootc update or rollback should not affect this application data.
+
+Having `/var` separate also makes it work cleanly to "stage" new
+operating system updates before applying them (they're downloaded
+and ready, but only take effect on reboot).
+
+In general, this is the same rationale for Docker `VOLUME`: decouple the application
+code from its data.
 
 A common case is for applications to want some directory structure (e.g. `/var/lib/postgresql`) to be pre-created.
 It's recommended to use [systemd tmpfiles.d](https://www.freedesktop.org/software/systemd/man/latest/tmpfiles.d.html)


### PR DESCRIPTION
- docs/filesystem: Some fixups for `/var`
    
---

- docs/filesystem: Expand on /usr
    
Motivated by discussion in bib.