### PR TITLE
test: use aws-cli to deploy aws instance instead of ansible module

### DIFF
--- a/plans/install-upgrade.fmf
+++ b/plans/install-upgrade.fmf
@@ -11,6 +11,8 @@ prepare:
       - jq
       - python3-devel
       - unzip
+  - how: shell
+    script: ansible-galaxy collection install community.general ansible.posix
 execute:
   how: tmt
 
@@ -27,9 +29,5 @@ execute:
     - when: arch != x86_64 and arch != aarch64
       enabled: false
   prepare+:
-    - how: shell
-      script: |
-        pip install boto3 botocore
-        ansible-galaxy collection install amazon.aws community.general ansible.posix
     - how: shell
       script: curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && unzip awscliv2.zip && sudo ./aws/install

--- a/tests/integration/playbooks/deploy-aws.yaml
+++ b/tests/integration/playbooks/deploy-aws.yaml
@@ -8,7 +8,6 @@
     ssh_key_pub: ""
     inventory_file: ""
     download_node: "{{ lookup('env', 'DOWNLOAD_NODE') | default('', true) }}"
-    ami_id: ""
     ami:
       x86_64:
         rhel-9-4: ami-044442bf4326c9933
@@ -41,61 +40,72 @@
         random_instance_type: "{{ lookup('env', 'instance_type') | default(instance_type[arch][instance_type_index], true) }}"
 
     - name: "get available zone for instance {{ random_instance_type }}"
-      shell: aws ec2 describe-instance-type-offerings --location-type availability-zone --filters="Name=instance-type,Values={{ random_instance_type }}" --query InstanceTypeOfferings | jq -r '.[0].Location'
+      shell: |
+        aws ec2 describe-instance-type-offerings \
+          --location-type availability-zone \
+          --filters="Name=instance-type,Values={{ random_instance_type }}" \
+          --query InstanceTypeOfferings | jq -r '.[0].Location'
       register: ec2_zone
       when: "'rhel' not in test_os"
 
     - name: get subnet
-      amazon.aws.ec2_vpc_subnet_info:
-        filters:
-          "tag:Name": "kite-ci"
-          "availabilityZone": "{{ ec2_zone.stdout }}"
+      shell: |
+        aws ec2 describe-subnets \
+          --output json \
+          --filters "Name=tag:Name,Values=kite-ci" "Name=availabilityZone,Values={{ ec2_zone.stdout }}" | \
+          jq -r ".Subnets[0].SubnetId"
       register: ec2_vpc_subnet
       when: "'rhel' not in test_os"
 
     - set_fact:
-        subnet_id: "{{ ec2_vpc_subnet.subnets[0].subnet_id }}"
+        subnet_id: "{{ ec2_vpc_subnet.stdout }}"
       when: "'rhel' not in test_os"
 
     - name: get virtqe subnet
-      amazon.aws.ec2_vpc_subnet_info:
-        filters:
-          "tag:Name": "InternalA-virtqe"
+      shell: |
+        aws ec2 describe-subnets \
+          --output json \
+          --filters "Name=tag:Name,Values=InternalA-virtqe" | \
+          jq -r ".Subnets[0].SubnetId"
       register: ec2_vpc_subnet
       when: '"rhel" in test_os'
 
     - set_fact:
-        subnet_id: "{{ ec2_vpc_subnet.subnets[0].subnet_id }}"
+        subnet_id: "{{ ec2_vpc_subnet.stdout }}"
       when: "'rhel' in test_os"
 
     - name: get security group
-      amazon.aws.ec2_security_group_info:
-        filters:
-          "tag:Name": "kite-ci"
+      shell: |
+        aws ec2 describe-security-groups \
+          --filters="Name=tag:Name,Values=kite-ci" \
+          --output json | \
+          jq -r ".SecurityGroups[0].GroupId"
       register: ec2_security_group
       when: "'rhel' not in test_os"
 
     - set_fact:
-        group_id: "{{ ec2_security_group.security_groups[0].group_id }}"
+        group_id: "{{ ec2_security_group.stdout }}"
       when: "'rhel' not in test_os"
 
     - name: get virtqe security group
-      amazon.aws.ec2_security_group_info:
-        filters:
-          "tag:Name": "bootc-test"
+      shell: |
+        aws ec2 describe-security-groups \
+          --filters="Name=tag:Name,Values=bootc-test" \
+          --output json | \
+          jq -r ".SecurityGroups[0].GroupId"
       register: ec2_security_group
       when: "'rhel' in test_os"
 
     - set_fact:
-        group_id: "{{ ec2_security_group.security_groups[0].group_id }}"
+        group_id: "{{ ec2_security_group.stdout }}"
       when: "'rhel' in test_os"
 
     - name: config ssh keypair used by test
-      amazon.aws.ec2_key:
-        name: "kp-bootc-{{ random_num }}"
-        key_material: "{{ lookup('file', ssh_key_pub) }}"
-        tags:
-          name: "bootc-test"
+      shell: |
+        aws ec2 import-key-pair \
+          --key-name "kp-bootc-{{ random_num }}" \
+          --public-key-material "fileb://{{ ssh_key_pub }}" \
+          --tag-specification 'ResourceType=key-pair,Tags=[{Key=Name,Value=bootc-test}]'
 
     - name: generate ec2_run_instance script
       template:
@@ -112,14 +122,16 @@
         instance_json: "{{ result_instance.stdout | from_json }}"
 
     - name: wait for instance running
-      shell: aws ec2 describe-instances --instance-ids {{ instance_json.Instances[0].InstanceId }} --query 'Reservations[0].Instances[0].State.Name' --output text
-      register: describe_result
-      retries: 60
-      delay: 5
-      until: describe_result.stdout == "running"
+      shell: |
+        aws ec2 wait instance-running \
+          --instance-ids {{ instance_json.Instances[0].InstanceId }}
 
     - name: get instance public ip
-      shell: aws ec2 describe-instances --instance-ids {{ instance_json.Instances[0].InstanceId }} --query 'Reservations[*].Instances[*].PublicIpAddress' --output text
+      shell: |
+        aws ec2 describe-instances \
+          --instance-ids {{ instance_json.Instances[0].InstanceId }} \
+          --query 'Reservations[*].Instances[*].PublicIpAddress' \
+          --output text
       register: ip_result
       when: "'rhel' not in test_os"
 
@@ -128,7 +140,11 @@
       when: "'rhel' not in test_os"
 
     - name: get instance private ip
-      shell: aws ec2 describe-instances --instance-ids {{ instance_json.Instances[0].InstanceId }} --query 'Reservations[*].Instances[*].PrivateIpAddress' --output text
+      shell: |
+        aws ec2 describe-instances \
+          --instance-ids {{ instance_json.Instances[0].InstanceId }} \
+          --query 'Reservations[*].Instances[*].PrivateIpAddress' \
+          --output text
       register: ip_result
       when: "'rhel' in test_os"
 
@@ -173,12 +189,4 @@
         section: cloud:vars
         option: instance_id
         value: "{{ instance_json.Instances[0].InstanceId }}"
-        no_extra_spaces: true
-
-    - name: write AWS ami id to inventory file
-      community.general.ini_file:
-        path: "{{ inventory_file }}"
-        section: cloud:vars
-        option: ami_id
-        value: "{{ ami_id }}"
         no_extra_spaces: true

--- a/tests/integration/playbooks/remove.yaml
+++ b/tests/integration/playbooks/remove.yaml
@@ -7,30 +7,18 @@
     - name: Remove AWS resources
       block:
         - name: terminate instance
-          amazon.aws.ec2_instance:
-            instance_ids: "{{ instance_id }}"
-            state: absent
-            wait: true
+          shell: |
+            aws ec2 terminate-instances \
+              --instance-ids "{{ instance_id }}"
           ignore_errors: true
 
         - name: wait until instance terminated
-          amazon.aws.ec2_instance_info:
-            instance_ids:
-              - "{{ instance_id }}"
-          register: result_instance_status
-          retries: 30
-          delay: 10
-          until: result_instance_status.instances[0].state.name == "terminated"
+          shell: |
+            aws ec2 wait instance-terminated \
+              --instance-ids "{{ instance_id }}"
 
         - name: remove ec2 key
-          amazon.aws.ec2_key:
-            name: "kp-bootc-{{ random_num }}"
-            state: absent
-
-        - name: Deregister AMI (delete associated snapshots too)
-          amazon.aws.ec2_ami:
-            image_id: "{{ ami_id }}"
-            delete_snapshot: true
-            state: absent
-          when: ami_id != ""
+          shell: |
+            aws ec2 delete-key-pair \
+              --key-name "kp-bootc-{{ random_num }}"
       when: platform == "aws"

--- a/tests/integration/playbooks/templates/ec2_run_instance.j2
+++ b/tests/integration/playbooks/templates/ec2_run_instance.j2
@@ -9,11 +9,7 @@
 {% if test_os.startswith('rhel') %}
     --user-data file://user-data \
 {% endif %}
-{% if ami_id == "" %}
     --image-id {{ ami[arch][test_os] }} \
-{% else %}
-    --image-id {{ ami_id }} \
-{% endif %}
     --instance-market-options MarketType=spot,SpotOptions=\{MaxPrice=0.1,SpotInstanceType=one-time,InstanceInterruptionBehavior=terminate\} \
     --instance-type {{ random_instance_type }} \
     --key-name kp-bootc-{{ random_num }} \


### PR DESCRIPTION
This PR will use `aws-cli` to deploy and remove AWS instance. The old ansible `amazon.aws` deployment will not be used. Removing test dependency always makes test stable.
And this PR also removed `ami_id` variable related code because it's not used in this case.