### PR TITLE
test: install ansible collection from tar.gz package

### DIFF
--- a/plans/install-upgrade.fmf
+++ b/plans/install-upgrade.fmf
@@ -12,7 +12,7 @@ prepare:
       - python3-devel
       - unzip
   - how: shell
-    script: ansible-galaxy collection install community.general ansible.posix
+    script: ansible-galaxy collection install https://ansible-collection.s3.amazonaws.com/ansible-posix-1.5.4.tar.gz https://ansible-collection.s3.amazonaws.com/community-general-8.5.0.tar.gz
 execute:
   how: tmt
 


### PR DESCRIPTION
To avoid galaxy server unstable issue, like `504 gateway timeout`, `error when getting available versions of collection community.general`, download two required collection packages and install them locally. And those two collections are more general and do not have too much update often. 