### PR TITLE
docs: Add link to the bootable containers webpage

### DIFF
--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -1,6 +1,7 @@
 # bootc
 
 Transactional, in-place operating system updates using OCI/Docker container images.
+bootc is the key component in a broader mission of [bootable containers](https://containers.github.io/bootable/).
 
 The original Docker container model of using "layers" to model
 applications has been extremely successful.  This project

--- a/docs/src/relationships.md
+++ b/docs/src/relationships.md
@@ -1,5 +1,8 @@
 # Relationship with other projects
 
+bootc is the key component in a broader mission of [bootable containers](https://containers.github.io/bootable/).
+Here's its relationship to other moving parts.
+
 ## Relationship with podman
 
 It gets a bit confusing to talk about shipping bootable operating systems in container images.


### PR DESCRIPTION
This helps share the broader context and mission of the project when thinking of it beyond bootc.