### PR TITLE
install: Support being passed --filesystem with no install config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,3 +148,42 @@ jobs:
           sudo podman run --rm -ti --privileged --env RUST_LOG=debug -v /:/target -v /var/lib/containers:/var/lib/containers -v ./usr/bin/bootc:/usr/bin/bootc --pid=host --security-opt label=disable \
             ${image} bootc install to-existing-root
           sudo podman run --rm -ti --privileged -v /:/target -v ./usr/bin/bootc:/usr/bin/bootc --pid=host --security-opt label=disable ${image} bootc internal-tests verify-selinux /target/ostree --warn
+  install-to-existing-root:
+    name: "Test install-to-existing-root"
+    needs: [build-c9s]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download
+        uses: actions/download-artifact@v4
+        with:
+          name: bootc-c9s.tar.zst
+      - name: Install
+        run: tar -xvf bootc.tar.zst
+      - name: Integration tests
+        run: |
+          set -xeuo pipefail
+          # We should be able to install to-existing-root with no install config,
+          # so we bind mount an empty directory over /usr/lib/bootc/install.
+          empty=$(mktemp -d)
+          image=quay.io/centos-bootc/centos-bootc-dev:stream9
+          sudo podman run --rm -ti --privileged --env RUST_LOG=debug -v /:/target -v /var/lib/containers:/var/lib/containers -v ./usr/bin/bootc:/usr/bin/bootc -v ${empty}:/usr/lib/bootc/install --pid=host --security-opt label=disable \
+            ${image} bootc install to-existing-root
+  install-to-loopback:
+    name: "Test install to-disk --via-loopback"
+    needs: [build-c9s]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download
+        uses: actions/download-artifact@v4
+        with:
+          name: bootc-c9s.tar.zst
+      - name: Install
+        run: tar -xvf bootc.tar.zst
+      - name: Integration tests
+        run: |
+          set -xeuo pipefail
+          image=quay.io/centos-bootc/centos-bootc-dev:stream9
+          tmpdisk=$(mktemp -p /var/tmp)
+          truncate -s 20G ${tmpdisk}
+          sudo podman run --rm -ti --privileged --env RUST_LOG=debug -v /dev:/dev -v /:/target -v /var/lib/containers:/var/lib/containers -v ./usr/bin/bootc:/usr/bin/bootc --pid=host --security-opt label=disable \
+            -v ${tmpdisk}:/disk ${image} bootc install to-disk --via-loopback /disk

--- a/lib/src/install/config.rs
+++ b/lib/src/install/config.rs
@@ -153,7 +153,7 @@ impl InstallConfiguration {
 
 #[context("Loading configuration")]
 /// Load the install configuration, merging all found configuration files.
-pub(crate) fn load_config() -> Result<InstallConfiguration> {
+pub(crate) fn load_config() -> Result<Option<InstallConfiguration>> {
     const SYSTEMD_CONVENTIONAL_BASES: &[&str] = &["/usr/lib", "/usr/local/lib", "/etc", "/run"];
     let fragments = liboverdrop::scan(SYSTEMD_CONVENTIONAL_BASES, "bootc/install", &["toml"], true);
     let mut config: Option<InstallConfiguration> = None;
@@ -177,8 +177,9 @@ pub(crate) fn load_config() -> Result<InstallConfiguration> {
             config = c.install;
         }
     }
-    let mut config = config.ok_or_else(|| anyhow::anyhow!("No bootc/install config found; this operating system must define a default configuration to be installable"))?;
-    config.canonicalize();
+    if let Some(config) = config.as_mut() {
+        config.canonicalize();
+    }
     Ok(config)
 }
 


### PR DESCRIPTION
This fixes a logical bug where for base images that don't have any install configuration at all, we errored out even if we were explicitly passed `--filesystem`.

This is just about making it easier to test base images that don't have an install config.