### PR TITLE
Add support for insecure registries (Fix: #461)

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -46,6 +46,11 @@ pub(crate) struct UpgradeOpts {
     /// a userspace-only restart.
     #[clap(long, conflicts_with = "check")]
     pub(crate) apply: bool,
+
+    /// Skip TLS and certificate verification.
+    /// This is very insecure and should only be used in testing environments
+    #[clap(long)]
+    pub(crate) insecure_disable_tls_verification: bool,
 }
 
 /// Perform an switch operation
@@ -62,6 +67,11 @@ pub(crate) struct SwitchOpts {
     /// This argument is deprecated and does nothing.
     #[clap(long, hide = true)]
     pub(crate) no_signature_verification: bool,
+
+    /// Skip TLS and certificate verification.
+    /// This is very insecure and should only be used in testing environments
+    #[clap(long)]
+    pub(crate) insecure_disable_tls_verification: bool,
 
     /// This is the inverse of the previous `--target-no-signature-verification` (which is now
     /// a no-op).
@@ -103,6 +113,11 @@ pub(crate) struct EditOpts {
     /// Don't display progress
     #[clap(long)]
     pub(crate) quiet: bool,
+
+    /// Skip TLS and certificate verification.
+    /// This is very insecure and should only be used in testing environments
+    #[clap(long)]
+    pub(crate) insecure_disable_tls_verification: bool,
 }
 
 /// Perform an status operation
@@ -494,7 +509,7 @@ async fn switch(opts: SwitchOpts) -> Result<()> {
         !opts.enforce_container_sigpolicy,
         opts.ostree_remote.as_deref(),
     );
-    let target = ostree_container::OstreeImageReference { sigverify, imgref };
+    let target = ostree_container::OstreeImageReference { sigverify, imgref, opts: opts.insecure_disable_tls_verification };
     let target = ImageReference::from(target);
 
     // If we're doing an in-place mutation, we shortcut most of the rest of the work here

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -618,6 +618,7 @@ async fn initialize_ostree_root_from_self(
             None
         };
         let proxy_cfg = ostree_container::store::ImageProxyConfig {
+            insecure_skip_tls_verification: src_imageref.insecure_disable_tls_verification,
             skopeo_cmd,
             ..Default::default()
         };

--- a/lib/src/spec.rs
+++ b/lib/src/spec.rs
@@ -74,6 +74,9 @@ pub struct ImageReference {
     /// Signature verification type
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signature: Option<ImageSignature>,
+    /// Skip TLS and certificate verification; this is very insecure and
+    /// should only be used in testing environments.
+    pub insecure_disable_tls_verification: bool,
 }
 
 /// The status of the booted image

--- a/lib/src/status.rs
+++ b/lib/src/status.rs
@@ -59,6 +59,7 @@ impl From<OstreeImageReference> for ImageReference {
             signature,
             transport: transport_to_string(imgref.imgref.transport),
             image: imgref.imgref.name,
+            insecure_disable_tls_verification: imgref.insecure_disable_tls_verification,
         }
     }
 }
@@ -71,6 +72,7 @@ impl From<ImageReference> for OstreeImageReference {
         };
         Self {
             sigverify,
+            insecure_disable_tls_verification: img.insecure_disable_tls_verification,
             imgref: ostree_container::ImageReference {
                 // SAFETY: We validated the schema in kube-rs
                 transport: img.transport.as_str().try_into().unwrap(),


### PR DESCRIPTION
- Introduce 'insecure-disable-tls-verification' parameter for skipping TLS verification;
- Fix Issue: #461.