### PR TITLE
bugfix: Switch losetup to --direct-io=off by default

### DIFF
--- a/docs/src/bootc-install.md
+++ b/docs/src/bootc-install.md
@@ -167,6 +167,8 @@ podman run --rm --privileged --pid=host --security-opt label=type:unconfined_t  
 
 Notice that we use `--generic-image` for this use case.
 
+Set the environment variable `BOOTC_DIRECT_IO=on` to create the loopback device with direct-io enabled.
+
 ### Using `bootc install to-existing-root`
 
 This is a variant of `install to-filesystem`, which maximizes convenience for using


### PR DESCRIPTION
When using a loopback device pointing to a file on a 9p filesystem (e.g. the home mount of a podman machine), using direct-io=on causes the partitioning via sgdisk to fail. This is a temporary fix until podman machine switches away from 9p or another fix is found. Direct IO can be enabled via the BOOTC_DIRECT_IO=on environment variable.

Fixes #485