### PR TITLE
install: Two informational patches

### DIFF
--- a/lib/src/install/baseline.rs
+++ b/lib/src/install/baseline.rs
@@ -143,7 +143,8 @@ fn mkfs<'a>(
     t.cmd.arg(dev);
     // All the mkfs commands are unnecessarily noisy by default
     t.cmd.stdout(Stdio::null());
-    t.run()?;
+    // But this one is notable so let's print the whole thing with verbose()
+    t.verbose().run()?;
     Ok(u)
 }
 
@@ -345,10 +346,12 @@ pub(crate) fn install_create_rootfs(
                 .args([base_rootdev.as_str()])
                 .run()?;
             // The --wipe-slot=all removes our temporary passphrase, and binds to the local TPM device.
+            // We also use .verbose() here as the details are important/notable.
             Task::new("Enrolling root device with TPM", "systemd-cryptenroll")
                 .args(["--wipe-slot=all", "--tpm2-device=auto", "--unlock-key-file"])
                 .args([tmp_keyfile])
                 .args([base_rootdev.as_str()])
+                .verbose()
                 .run_with_stdin_buf(dummy_passphrase_input)?;
             Task::new("Opening root LUKS device", "cryptsetup")
                 .args(["luksOpen", base_rootdev.as_str(), luks_name])

--- a/lib/src/install/baseline.rs
+++ b/lib/src/install/baseline.rs
@@ -50,9 +50,10 @@ impl Display for Filesystem {
     }
 }
 
-#[derive(clap::ValueEnum, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(clap::ValueEnum, Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum BlockSetup {
+    #[default]
     Direct,
     Tpm2Luks,
 }
@@ -60,12 +61,6 @@ pub(crate) enum BlockSetup {
 impl Display for BlockSetup {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.to_possible_value().unwrap().get_name().fmt(f)
-    }
-}
-
-impl Default for BlockSetup {
-    fn default() -> Self {
-        Self::Direct
     }
 }
 


### PR DESCRIPTION
install: Explicitly print which block setup we're using

This is an important thing.

Signed-off-by: Colin Walters <walters@verbum.org>

---

install: Print more information when making filesystems

- Label is mandatory so change the API to always take it
- Print the label we're using as a description of the fs
- Also print the fs type as it's notable info

Signed-off-by: Colin Walters <walters@verbum.org>

---

