### PR TITLE
test: update test to use `updates` compose to align with rhel-bootc image

### DIFF
--- a/tests/integration/files/rhel-9.template
+++ b/tests/integration/files/rhel-9.template
@@ -1,10 +1,10 @@
 [rhel-9x-baseos]
-baseurl=http://REPLACE_ME/rhel-9/nightly/RHEL-9/REPLACE_COMPOSE_ID/compose/BaseOS/$basearch/os/
+baseurl=http://REPLACE_ME/rhel-9/composes/RHEL-9/REPLACE_COMPOSE_ID/compose/BaseOS/$basearch/os/
 enabled=1
 gpgcheck=0
 
 [rhel-9x-appstream]
-baseurl=http://REPLACE_ME/rhel-9/nightly/RHEL-9/REPLACE_COMPOSE_ID/compose/AppStream/$basearch/os/
+baseurl=http://REPLACE_ME/rhel-9/composes/RHEL-9/REPLACE_COMPOSE_ID/compose/AppStream/$basearch/os/
 enabled=1
 gpgcheck=0
 

--- a/tests/integration/install-upgrade.sh
+++ b/tests/integration/install-upgrade.sh
@@ -52,12 +52,12 @@ case "$TEST_OS" in
 yum_repos:
   rhel-9x-baseos:
     name: rhel-9x-baseos
-    baseurl: http://${DOWNLOAD_NODE}/rhel-9/nightly/RHEL-9/${CURRENT_COMPOSE_RHEL94}/compose/BaseOS/${ARCH}/os/
+    baseurl: http://${DOWNLOAD_NODE}/rhel-9/composes/RHEL-9/${CURRENT_COMPOSE_RHEL94}/compose/BaseOS/${ARCH}/os/
     enabled: true
     gpgcheck: false
   rhel-9x-appstream:
     name: rhel-9x-appstream
-    baseurl: http://${DOWNLOAD_NODE}/rhel-9/nightly/RHEL-9/${CURRENT_COMPOSE_RHEL94}/compose/AppStream/${ARCH}/os/
+    baseurl: http://${DOWNLOAD_NODE}/rhel-9/composes/RHEL-9/${CURRENT_COMPOSE_RHEL94}/compose/AppStream/${ARCH}/os/
     enabled: true
     gpgcheck: false
 EOF

--- a/tests/integration/mockbuild.sh
+++ b/tests/integration/mockbuild.sh
@@ -34,19 +34,19 @@ case "$TEST_OS" in
         tee -a /etc/mock/templates/"$TEMPLATE" > /dev/null << EOF
 [BaseOS]
 name=Red Hat Enterprise Linux - BaseOS
-baseurl=http://${DOWNLOAD_NODE}/rhel-9/nightly/RHEL-9/${CURRENT_COMPOSE_RHEL94}/compose/BaseOS/\$basearch/os/
+baseurl=http://${DOWNLOAD_NODE}/rhel-9/composes/RHEL-9/${CURRENT_COMPOSE_RHEL94}/compose/BaseOS/\$basearch/os/
 enabled=1
 gpgcheck=0
 
 [AppStream]
 name=Red Hat Enterprise Linux - AppStream
-baseurl=http://${DOWNLOAD_NODE}/rhel-9/nightly/RHEL-9/${CURRENT_COMPOSE_RHEL94}/compose/AppStream/\$basearch/os/
+baseurl=http://${DOWNLOAD_NODE}/rhel-9/composes/RHEL-9/${CURRENT_COMPOSE_RHEL94}/compose/AppStream/\$basearch/os/
 enabled=1
 gpgcheck=0
 
 [CRB]
 name = Red Hat Enterprise Linux - CRB
-baseurl = http://${DOWNLOAD_NODE}/rhel-9/nightly/RHEL-9/${CURRENT_COMPOSE_RHEL94}/compose/CRB/\$basearch/os/
+baseurl = http://${DOWNLOAD_NODE}/rhel-9/composes/RHEL-9/${CURRENT_COMPOSE_RHEL94}/compose/CRB/\$basearch/os/
 enabled = 1
 gpgcheck = 0
 """


### PR DESCRIPTION
Since `rhel-bootc` image started using `updates` compose, the test should be updated as well.
This PR changed rhel compose URL to the same as what rhel-bootc used. That avoids compose update between nightly and updates.