### PR TITLE
install: Add prominent warning+timeout when targeting host root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Install
         run: sudo tar -C / -xvf bootc.tar.zst
       - name: Integration tests
-        run: sudo podman run --rm -ti --privileged -v /run/systemd:/run/systemd -v /:/run/host -v /usr/bin/bootc:/usr/bin/bootc --pid=host quay.io/fedora/fedora-coreos:testing-devel bootc internal-tests run-privileged-integration
+        run: sudo podman run --rm --privileged -v /run/systemd:/run/systemd -v /:/run/host -v /usr/bin/bootc:/usr/bin/bootc --pid=host quay.io/fedora/fedora-coreos:testing-devel bootc internal-tests run-privileged-integration
   container-tests:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'control/skip-ci') }}
     name: "Container testing"
@@ -146,7 +146,7 @@ jobs:
           set -xeuo pipefail
           image=quay.io/centos-bootc/centos-bootc-dev:stream9 
           echo 'ssh-ed25519 ABC0123 testcase@example.com' > test_authorized_keys
-          sudo podman run --rm -ti --privileged -v ./test_authorized_keys:/test_authorized_keys --env RUST_LOG=debug -v /:/target -v /var/lib/containers:/var/lib/containers -v ./usr/bin/bootc:/usr/bin/bootc --pid=host --security-opt label=disable \
+          sudo podman run --rm --privileged -v ./test_authorized_keys:/test_authorized_keys --env RUST_LOG=debug -v /:/target -v /var/lib/containers:/var/lib/containers -v ./usr/bin/bootc:/usr/bin/bootc --pid=host --security-opt label=disable \
             ${image} bootc install to-filesystem --acknowledge-destructive \
             --karg=foo=bar --disable-selinux --replace=alongside --root-ssh-authorized-keys=/test_authorized_keys /target
           ls -al /boot/loader/
@@ -155,9 +155,9 @@ jobs:
           # TODO fix https://github.com/containers/bootc/pull/137
           sudo chattr -i /ostree/deploy/default/deploy/*
           sudo rm /ostree/deploy/default -rf
-          sudo podman run --rm -ti --privileged --env RUST_LOG=debug -v /:/target -v /var/lib/containers:/var/lib/containers -v ./usr/bin/bootc:/usr/bin/bootc --pid=host --security-opt label=disable \
+          sudo podman run --rm --privileged --env RUST_LOG=debug -v /:/target -v /var/lib/containers:/var/lib/containers -v ./usr/bin/bootc:/usr/bin/bootc --pid=host --security-opt label=disable \
             ${image} bootc install to-existing-root --acknowledge-destructive
-          sudo podman run --rm -ti --privileged -v /:/target -v ./usr/bin/bootc:/usr/bin/bootc --pid=host --security-opt label=disable ${image} bootc internal-tests verify-selinux /target/ostree --warn
+          sudo podman run --rm --privileged -v /:/target -v ./usr/bin/bootc:/usr/bin/bootc --pid=host --security-opt label=disable ${image} bootc internal-tests verify-selinux /target/ostree --warn
   install-to-existing-root:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'control/skip-ci') }}
     name: "Test install-to-existing-root"
@@ -177,7 +177,7 @@ jobs:
           # so we bind mount an empty directory over /usr/lib/bootc/install.
           empty=$(mktemp -d)
           image=quay.io/centos-bootc/centos-bootc-dev:stream9
-          sudo podman run --rm -ti --privileged --env RUST_LOG=debug -v /:/target -v /var/lib/containers:/var/lib/containers -v ./usr/bin/bootc:/usr/bin/bootc -v ${empty}:/usr/lib/bootc/install --pid=host --security-opt label=disable \
+          sudo podman run --rm --privileged --env RUST_LOG=debug -v /:/target -v /var/lib/containers:/var/lib/containers -v ./usr/bin/bootc:/usr/bin/bootc -v ${empty}:/usr/lib/bootc/install --pid=host --security-opt label=disable \
             ${image} bootc install to-existing-root
   install-to-loopback:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'control/skip-ci') }}
@@ -197,5 +197,5 @@ jobs:
           image=quay.io/centos-bootc/centos-bootc-dev:stream9
           tmpdisk=$(mktemp -p /var/tmp)
           truncate -s 20G ${tmpdisk}
-          sudo podman run --rm -ti --privileged --env RUST_LOG=debug -v /dev:/dev -v /:/target -v /var/lib/containers:/var/lib/containers -v ./usr/bin/bootc:/usr/bin/bootc --pid=host --security-opt label=disable \
+          sudo podman run --rm --privileged --env RUST_LOG=debug -v /dev:/dev -v /:/target -v /var/lib/containers:/var/lib/containers -v ./usr/bin/bootc:/usr/bin/bootc --pid=host --security-opt label=disable \
             -v ${tmpdisk}:/disk ${image} bootc install to-disk --via-loopback /disk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
           image=quay.io/centos-bootc/centos-bootc-dev:stream9 
           echo 'ssh-ed25519 ABC0123 testcase@example.com' > test_authorized_keys
           sudo podman run --rm -ti --privileged -v ./test_authorized_keys:/test_authorized_keys --env RUST_LOG=debug -v /:/target -v /var/lib/containers:/var/lib/containers -v ./usr/bin/bootc:/usr/bin/bootc --pid=host --security-opt label=disable \
-            ${image} bootc install to-filesystem \
+            ${image} bootc install to-filesystem --acknowledge-destructive \
             --karg=foo=bar --disable-selinux --replace=alongside --root-ssh-authorized-keys=/test_authorized_keys /target
           ls -al /boot/loader/
           sudo grep foo=bar /boot/loader/entries/*.conf
@@ -156,7 +156,7 @@ jobs:
           sudo chattr -i /ostree/deploy/default/deploy/*
           sudo rm /ostree/deploy/default -rf
           sudo podman run --rm -ti --privileged --env RUST_LOG=debug -v /:/target -v /var/lib/containers:/var/lib/containers -v ./usr/bin/bootc:/usr/bin/bootc --pid=host --security-opt label=disable \
-            ${image} bootc install to-existing-root
+            ${image} bootc install to-existing-root --acknowledge-destructive
           sudo podman run --rm -ti --privileged -v /:/target -v ./usr/bin/bootc:/usr/bin/bootc --pid=host --security-opt label=disable ${image} bootc internal-tests verify-selinux /target/ostree --warn
   install-to-existing-root:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'control/skip-ci') }}

--- a/tests/kolainst/install
+++ b/tests/kolainst/install
@@ -29,7 +29,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     COPY usr usr
 EOF
     podman build -t localhost/testimage .
-    podman run --rm -ti --privileged --pid=host --env RUST_LOG=error,bootc_lib::install=debug \
+    podman run --rm --privileged --pid=host --env RUST_LOG=error,bootc_lib::install=debug \
       localhost/testimage bootc install to-disk --skip-fetch-check --karg=foo=bar ${DEV}
     # In theory we could e.g. wipe the bootloader setup on the primary disk, then reboot;
     # but for now let's just sanity test that the install command executes.


### PR DESCRIPTION
It was raised in a discussion that it's rather easy to copy-paste this command you may find in a document and not fully understand what it does.

Let's prominently warn by default, with a timeout.