### PR TITLE
Update MSRV to 1.75

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ name = "bootc-lib"
 readme = "README.md"
 repository = "https://github.com/containers/bootc"
 version = "0.1.10"
-rust-version = "1.64.0"
+rust-version = "1.75.0"
 build = "build.rs"
 
 include = ["/src", "LICENSE-APACHE", "LICENSE-MIT"]


### PR DESCRIPTION
Currently the effective MSRV is 1.74.1 per `cargo msrv`.  We have 1.75
available in c9s, so let's target that at minimum.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>