### PR TITLE
docs: Various doc improvements

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -20,20 +20,21 @@
 - [Offline/disconnected updates](offline-updates.md)
 - [Booting local builds](booting-local-builds.md)
 - [`man bootc`](man/bootc.md)
-- [`man bootc status`](man/bootc-status.md)
-- [`man bootc upgrade`](man/bootc-upgrade.md)
-- [`man bootc switch`](man/bootc-switch.md)
-- [`man bootc rollback`](man/bootc-rollback.md)
-- [`man bootc usr-overlay`](man/bootc-usr-overlay.md)
+- [`man bootc-status`](man/bootc-status.md)
+- [`man bootc-upgrade`](man/bootc-upgrade.md)
+- [`man bootc-switch`](man/bootc-switch.md)
+- [`man bootc-rollback`](man/bootc-rollback.md)
+- [`man bootc-usr-overlay`](man/bootc-usr-overlay.md)
 - [`man bootc-fetch-apply-updates.service`](man-md/bootc-fetch-apply-updates-service.md)
 
 # Using `bootc install`
 
 - [Understanding `bootc install`](bootc-install.md)
-- [`man bootc-install.md`](man/bootc-install.md)
+- [`man bootc-install`](man/bootc-install.md)
 - [`man bootc-install-config`](man-md/bootc-install-config.md)
-- [`man bootc-install-to-disk.md`](man/bootc-install-to-disk.md)
-- [`man bootc-install-to-filesystem.md`](man/bootc-install-to-filesystem.md)
+- [`man bootc-install-to-disk`](man/bootc-install-to-disk.md)
+- [`man bootc-install-to-filesystem`](man/bootc-install-to-filesystem.md)
+- [`man bootc-install-to-existing-root`](man/bootc-install-to-existing-root.md)
 
 # Architecture
 

--- a/docs/src/man-md/bootc-install-config.md
+++ b/docs/src/man-md/bootc-install-config.md
@@ -18,7 +18,7 @@ that can be overridden in a derived container image.
 
 This is the only defined toplevel table.
 
-The `install`` section supports two subfields:
+The `install` section supports two subfields:
 
 - `block`: An array of supported `to-disk` backends enabled by this base container image;
    if not specified, this will just be `direct`.  The only other supported value is `tpm2-luks`.


### PR DESCRIPTION
1. Correct a typo in bootc-install-config.md
2. Keep the same format for man usage
3. Remove ".md" suffix in some man description
4. Add missing "bootc-install-to-existing-root"