### PR TITLE
install/to-disk: Drop separate /boot by default

### DIFF
--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -1195,8 +1195,9 @@ async fn install_to_filesystem_impl(state: &State, rootfs: &mut RootSetup) -> Re
 
     // Finalize mounted filesystems
     if !rootfs.skip_finalize {
-        let bootfs = rootfs.rootfs.join("boot");
-        for fs in [bootfs.as_path(), rootfs.rootfs.as_path()] {
+        let bootfs = rootfs.boot.as_ref().map(|_| rootfs.rootfs.join("boot"));
+        let bootfs = bootfs.as_ref().map(|p| p.as_path());
+        for fs in std::iter::once(rootfs.rootfs.as_path()).chain(bootfs) {
             finalize_filesystem(fs)?;
         }
     }


### PR DESCRIPTION
In order to simplify what we're doing here, let's drop the separate `/boot` aka XBOOTLDR partition by default for the `to-disk --block-setup=direct` path (the default).

We retain it when using `--block-setup=tpm2-luks` as it's required there.

Notably this kills off a hardcoded "ext4 for /boot" which is suboptimal for many reasons.

Longer term again I'd like to emphasize `install to-filesystem` with external installers, plus integrating external installation scripts as part of `bootc install to-disk`.

xref:
- https://github.com/containers/bootc/issues/499
- https://github.com/containers/bootc/issues/440