### PR TITLE
docs: Fix incorrect link for bootc-install-config

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -31,7 +31,7 @@
 
 - [Understanding `bootc install`](bootc-install.md)
 - [`man bootc-install.md`](man/bootc-install.md)
-- [`man bootc-install-config`](man/bootc-install-config.md)
+- [`man bootc-install-config`](man-md/bootc-install-config.md)
 - [`man bootc-install-to-disk.md`](man/bootc-install-to-disk.md)
 - [`man bootc-install-to-filesystem.md`](man/bootc-install-to-filesystem.md)
 

--- a/docs/src/bootc-install.md
+++ b/docs/src/bootc-install.md
@@ -119,7 +119,7 @@ taking precedence.  If for example you are building a derived container image fr
 you could create a `50-myos.toml`  that sets `type = "btrfs"` which will override the
 prior setting.
 
-For other available options, see [bootc-install-config](man/bootc-install-config.md).
+For other available options, see [bootc-install-config](man-md/bootc-install-config.md).
 
 ## Installing an "unconfigured" image
 


### PR DESCRIPTION
I incorrectly "fixed" this once alrady in:

https://github.com/containers/bootc/commit/ee78e9e7a07248c5690e3824f544aaea3d81069c

This effectively reverts that change to SUMMARY.md and performs the
correct change in boot-install.md instead.
