### PR TITLE
Release v0.1.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "bootc-lib"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anstream",
  "anstyle",

--- a/docs/src/man/bootc-edit.md
+++ b/docs/src/man/bootc-edit.md
@@ -40,4 +40,4 @@ Only changes to the \`spec\` section are honored.
 
 # VERSION
 
-v0.1.9
+v0.1.11

--- a/docs/src/man/bootc-install-print-configuration.md
+++ b/docs/src/man/bootc-install-print-configuration.md
@@ -31,4 +31,4 @@ string-valued filesystem name suitable for passing to \`mkfs.\$type\`.
 
 # VERSION
 
-v0.1.9
+v0.1.11

--- a/docs/src/man/bootc-install-to-disk.md
+++ b/docs/src/man/bootc-install-to-disk.md
@@ -23,7 +23,7 @@ Install to the target block device
 
 :   Automatically wipe all existing data on device
 
-**\--block-setup**=*BLOCK_SETUP* \[default: direct\]
+**\--block-setup**=*BLOCK_SETUP*
 
 :   Target root block device setup.
 
@@ -139,4 +139,4 @@ firmware will be skipped
 
 # VERSION
 
-v0.1.9
+v0.1.11

--- a/docs/src/man/bootc-install-to-existing-root.md
+++ b/docs/src/man/bootc-install-to-existing-root.md
@@ -11,7 +11,8 @@ root filesystem
 \[**\--target-ostree-remote**\] \[**\--skip-fetch-check**\]
 \[**\--disable-selinux**\] \[**\--karg**\]
 \[**\--root-ssh-authorized-keys**\] \[**\--generic-image**\]
-\[**-h**\|**\--help**\] \[**-V**\|**\--version**\] \[*ROOT_PATH*\]
+\[**\--acknowledge-destructive**\] \[**-h**\|**\--help**\]
+\[**-V**\|**\--version**\] \[*ROOT_PATH*\]
 
 # DESCRIPTION
 
@@ -108,6 +109,10 @@ boot.
 \- All bootloader types will be installed - Changes to the system
 firmware will be skipped
 
+**\--acknowledge-destructive**
+
+:   Accept that this is a destructive action and skip a warning timer
+
 **-h**, **\--help**
 
 :   Print help (see a summary with -h)
@@ -123,4 +128,4 @@ firmware will be skipped
 
 # VERSION
 
-v0.1.9
+v0.1.11

--- a/docs/src/man/bootc-install-to-filesystem.md
+++ b/docs/src/man/bootc-install-to-filesystem.md
@@ -5,10 +5,12 @@ bootc-install-to-filesystem - Install to the target filesystem
 # SYNOPSIS
 
 **bootc-install-to-filesystem** \[**\--root-mount-spec**\]
-\[**\--boot-mount-spec**\] \[**\--replace**\] \[**\--source-imgref**\]
-\[**\--target-transport**\] \[**\--target-imgref**\]
-\[**\--enforce-container-sigpolicy**\] \[**\--target-ostree-remote**\]
-\[**\--skip-fetch-check**\] \[**\--disable-selinux**\] \[**\--karg**\]
+\[**\--boot-mount-spec**\] \[**\--replace**\]
+\[**\--acknowledge-destructive**\] \[**\--skip-finalize**\]
+\[**\--source-imgref**\] \[**\--target-transport**\]
+\[**\--target-imgref**\] \[**\--enforce-container-sigpolicy**\]
+\[**\--target-ostree-remote**\] \[**\--skip-fetch-check**\]
+\[**\--disable-selinux**\] \[**\--karg**\]
 \[**\--root-ssh-authorized-keys**\] \[**\--generic-image**\]
 \[**-h**\|**\--help**\] \[**-V**\|**\--version**\] \<*ROOT_PATH*\>
 
@@ -48,6 +50,18 @@ be used.
 >     bootloader state will have its contents wiped and replaced.
 >     However, the running system (and all files) will remain in place
 >     until reboot
+
+**\--acknowledge-destructive**
+
+:   If the target is the running systems root filesystem, this will skip
+    any warnings
+
+**\--skip-finalize**
+
+:   The default mode is to \"finalize\" the target filesystem by
+    invoking \`fstrim\` and similar operations, and finally mounting it
+    readonly. This option skips those operations. It is then the
+    responsibility of the invoking code to perform those operations
 
 **\--source-imgref**=*SOURCE_IMGREF*
 
@@ -139,4 +153,4 @@ mounting. To override this, use \`\--root-mount-spec\`.
 
 # VERSION
 
-v0.1.9
+v0.1.11

--- a/docs/src/man/bootc-install.md
+++ b/docs/src/man/bootc-install.md
@@ -11,7 +11,7 @@ bootc-install - Install the running container to a target
 
 Install the running container to a target.
 
-## Understanding installations
+\## Understanding installations
 
 OCI containers are effectively layers of tarballs with JSON for
 metadata; they cannot be booted directly. The \`bootc install\` flow is
@@ -65,4 +65,4 @@ bootc-install-help(8)
 
 # VERSION
 
-v0.1.9
+v0.1.11

--- a/docs/src/man/bootc-rollback.md
+++ b/docs/src/man/bootc-rollback.md
@@ -38,4 +38,4 @@ rollback invocation.
 
 # VERSION
 
-v0.1.9
+v0.1.11

--- a/docs/src/man/bootc-status.md
+++ b/docs/src/man/bootc-status.md
@@ -37,4 +37,4 @@ The exact API format is not currently declared stable.
 
 # VERSION
 
-v0.1.9
+v0.1.11

--- a/docs/src/man/bootc-switch.md
+++ b/docs/src/man/bootc-switch.md
@@ -16,7 +16,7 @@ Target a new container image reference to boot.
 This is almost exactly the same operation as \`upgrade\`, but
 additionally changes the container image reference instead.
 
-## Usage
+\## Usage
 
 A common pattern is to have a management agent control operating system
 updates via container image tags; for example,
@@ -65,4 +65,4 @@ includes a default policy which requires signatures.
 
 # VERSION
 
-v0.1.9
+v0.1.11

--- a/docs/src/man/bootc-upgrade.md
+++ b/docs/src/man/bootc-upgrade.md
@@ -23,7 +23,7 @@ if the system has changed.
 
 However, in the future this is likely to change such that reboots
 outside of a \`bootc upgrade \--apply\` do \*not\* automatically apply
-the update.
+the update in addition.
 
 # OPTIONS
 
@@ -56,4 +56,4 @@ userspace-only restart.
 
 # VERSION
 
-v0.1.9
+v0.1.11

--- a/docs/src/man/bootc-usr-overlay.md
+++ b/docs/src/man/bootc-usr-overlay.md
@@ -12,22 +12,20 @@ will be discarded on reboot
 Adds a transient writable overlayfs on \`/usr\` that will be discarded
 on reboot.
 
-(`usroverlay` is an alias for this command)
-
-## Use cases
+\## Use cases
 
 A common pattern is wanting to use tracing/debugging tools, such as
 \`strace\` that may not be in the base image. A system package manager
 such as \`apt\` or \`dnf\` can apply changes into this transient overlay
 that will be discarded on reboot.
 
-## /etc and /var
+\## /etc and /var
 
 However, this command has no effect on \`/etc\` and \`/var\` - changes
 written there will persist. It is common for package installations to
 modify these directories.
 
-## Unmounting
+\## Unmounting
 
 Almost always, a system process will hold a reference to the open mount
 point. You can however invoke \`umount -l /usr\` to perform a \"lazy
@@ -45,4 +43,4 @@ unmount\".
 
 # VERSION
 
-v0.1.9
+v0.1.11

--- a/docs/src/man/bootc.md
+++ b/docs/src/man/bootc.md
@@ -16,9 +16,7 @@ The \`bootc\` project currently uses ostree-containers as a backend to
 support a model of bootable container images. Once installed, whether
 directly via \`bootc install\` (executed as part of a container) or via
 another mechanism such as an OS installer tool, further updates can be
-pulled via e.g. \`bootc upgrade\`.
-
-Changes in \`/etc\` and \`/var\` persist.
+pulled and \`bootc upgrade\`.
 
 # OPTIONS
 
@@ -70,4 +68,4 @@ bootc-help(8)
 
 # VERSION
 
-v0.1.9
+v0.1.11

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT OR Apache-2.0"
 name = "bootc-lib"
 readme = "README.md"
 repository = "https://github.com/containers/bootc"
-version = "0.1.10"
+version = "0.1.11"
 rust-version = "1.75.0"
 build = "build.rs"
 


### PR DESCRIPTION
Regenerate manpages too.  I notice here that we're getting some unnecessary quoting in the man pages since I think the tooling doesn't know whether or not we're writing markdown in the Rust source comments or not.

More medium term we'll have to figure out a better workflow for this.