### PR TITLE
install: A few minor patches

### DIFF
--- a/lib/src/bootloader.rs
+++ b/lib/src/bootloader.rs
@@ -27,5 +27,8 @@ pub(crate) fn install_via_bootupd(
             device.as_str(),
             rootfs.as_str(),
         ]);
-    Task::new_and_run("Running bootupctl to install bootloader", "bootupctl", args)
+    Task::new("Running bootupctl to install bootloader", "bootupctl")
+        .args(args)
+        .verbose()
+        .run()
 }

--- a/lib/src/bootloader.rs
+++ b/lib/src/bootloader.rs
@@ -21,8 +21,6 @@ pub(crate) fn install_via_bootupd(
         .chain(verbose)
         .chain(bootupd_opts.iter().copied().flatten())
         .chain([
-            "--src-root",
-            "/",
             "--device",
             device.as_str(),
             rootfs.as_str(),

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -650,10 +650,11 @@ async fn initialize_ostree_root_from_self(
     options.kargs = Some(kargs.as_slice());
     options.target_imgref = Some(&state.target_imgref);
     options.proxy_cfg = proxy_cfg;
-    println!("Deploying container image");
-    let imgstate =
-        ostree_container::deploy::deploy(&sysroot, stateroot, &src_imageref, Some(options)).await?;
-    println!("Deployment complete");
+    let imgstate = crate::utils::async_task_with_spinner(
+        "Deploying container image",
+        ostree_container::deploy::deploy(&sysroot, stateroot, &src_imageref, Some(options)),
+    )
+    .await?;
 
     sysroot.load(cancellable)?;
     let deployment = sysroot

--- a/lib/src/install/baseline.rs
+++ b/lib/src/install/baseline.rs
@@ -434,6 +434,7 @@ pub(crate) fn install_create_rootfs(
         let espdev = &findpart(esp_partno)?;
         Task::new("Creating ESP filesystem", "mkfs.fat")
             .args([espdev.as_str(), "-n", "EFI-SYSTEM"])
+            .verbose()
             .quiet_output()
             .run()?;
         let efifs_path = bootfs.join(crate::bootloader::EFI_DIR);


### PR DESCRIPTION
install: Add a spinner for container deployment

This can take substantial time.

Signed-off-by: Colin Walters <walters@verbum.org>

---

install: Be verbose for EFI creation and bootloader install

We previously changed the rootfs `mkfs` invocation to be
verbose; for consistency let's do the same for the EFI partition
as well as the bootloader run just so people can see
what's going on more.

Signed-off-by: Colin Walters <walters@verbum.org>

---

bootloader: Drop --src-root /

It's the default.

Signed-off-by: Colin Walters <walters@verbum.org>

---

