### PR TITLE
Add support for (weakly) "lifecycle bound" podman images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,7 @@ dependencies = [
  "openssl",
  "ostree-ext",
  "regex",
+ "rust-ini",
  "rustix",
  "schemars",
  "serde",
@@ -399,6 +400,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "containers-image-proxy"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,6 +463,12 @@ checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -579,6 +606,15 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1374,6 +1410,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.3",
+]
+
+[[package]]
 name = "ostree"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1676,6 +1722,17 @@ name = "roff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
+
+[[package]]
+name = "rust-ini"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d625ed57d8f49af6cfa514c42e1a71fadcff60eb0b1c517ff82fe41aa025b41"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+ "trim-in-place",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -2084,6 +2141,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2256,6 +2322,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "trim-in-place"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
 
 [[package]]
 name = "typenum"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -47,6 +47,7 @@ tempfile = "3.10.1"
 toml = "0.8.12"
 xshell = { version = "0.2.6", optional = true }
 uuid = { version = "1.8.0", features = ["v4"] }
+rust-ini = "0.21.0"
 
 [features]
 default = ["install"]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -45,7 +45,6 @@ mod k8sapitypes;
 mod kernel;
 #[cfg(feature = "install")]
 pub(crate) mod mount;
-#[cfg(feature = "install")]
 mod podman;
 pub mod spec;
 

--- a/lib/src/podman.rs
+++ b/lib/src/podman.rs
@@ -1,4 +1,11 @@
-use anyhow::{anyhow, Result};
+use std::collections::HashSet;
+use std::io::{BufReader, Read};
+
+use anyhow::{anyhow, Context, Result};
+use camino::Utf8Path;
+use cap_std_ext::cap_std::fs::Dir;
+use cap_std_ext::dirext::CapStdExtDirExt;
+use fn_error_context::context;
 use serde::Deserialize;
 
 use crate::install::run_in_host_mountns;
@@ -7,6 +14,9 @@ use crate::task::Task;
 /// Where we look inside our container to find our own image
 /// for use with `bootc install`.
 pub(crate) const CONTAINER_STORAGE: &str = "/var/lib/containers";
+/// Currently a magic comment which instructs bootc it should pull these
+/// images.
+pub(crate) const BOOTC_BOUND_FLAG: &str = "# bootc: bound";
 
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
@@ -26,4 +36,61 @@ pub(crate) fn imageid_to_digest(imgid: &str) -> Result<String> {
         .next()
         .ok_or_else(|| anyhow!("No images returned for inspect"))?;
     Ok(i.digest)
+}
+
+/// List all container `.image` files described in the target root
+#[context("Listing .image files")]
+pub(crate) fn list_container_images(root: &Dir) -> Result<(usize, HashSet<String>)> {
+    const ETC_ROOT: &str = "etc/containers/systemd";
+    const USR_ROOT: &str = "usr/share/containers/systemd";
+
+    let mut found_image_files = 0;
+    let mut r = HashSet::new();
+    for d in [ETC_ROOT, USR_ROOT] {
+        let imagedir = if let Some(d) = root.open_dir_optional(d)? {
+            d
+        } else {
+            tracing::debug!("No {d} found");
+            continue;
+        };
+        for entry in imagedir.entries()? {
+            let entry = entry?;
+            if !entry.file_type()?.is_file() {
+                continue;
+            }
+            let name = entry.file_name();
+            let name = if let Some(n) = name.to_str() {
+                n
+            } else {
+                anyhow::bail!("Invalid non-UTF8 filename: {name:?} in {d}");
+            };
+            if !matches!(Utf8Path::new(name).extension(), Some("image")) {
+                continue;
+            }
+            found_image_files += 1;
+            let mut buf = String::new();
+            entry.open().map(BufReader::new)?.read_to_string(&mut buf)?;
+            let mut is_bound = false;
+            for line in buf.lines() {
+                if line.starts_with(BOOTC_BOUND_FLAG) {
+                    is_bound = true;
+                    break;
+                }
+            }
+            if !is_bound {
+                tracing::trace!("{name}: Did not find {BOOTC_BOUND_FLAG}");
+                continue;
+            }
+            let config = ini::Ini::load_from_str(&buf).with_context(|| format!("{name}:"))?;
+            let image = if let Some(img) = config.get_from(Some("Container"), "Image") {
+                img
+            } else {
+                tracing::debug!("{name}: Missing Container/Image key");
+                continue;
+            };
+            tracing::trace!("{name}: Bound {image}");
+            r.insert(image.to_string());
+        }
+    }
+    Ok((found_image_files, r))
 }


### PR DESCRIPTION
This is a working PoC implementation of part of
https://github.com/containers/bootc/issues/128

Demo:

```
$ cat Containerfile
FROM localhost/bootc
COPY *.image /usr/share/containers/systemd
$ cat foo.image
[Container]
# bootc: bound
Image=quay.io/centos/centos:stream9
$ podman build -t localhost/testbootc .
$ podman-bootc run localhost/testbootc
...
[root@ibm-p8-kvm-03-guest-02 ~]# podman images
REPOSITORY             TAG         IMAGE ID      CREATED       SIZE
quay.io/centos/centos  stream9     75a875ea6cd8  43 hours ago  163 MB
[root@ibm-p8-kvm-03-guest-02 ~]#
```

---

Example user story:

- Admin can take the standard podman-systemd .image files they have and add a special marker
- When generating a disk image *and* at `bootc upgrade` time, bootc will pre-fetch these container images into the standard `/var/lib/containers/storage` location
- This means the default case avoids firstboot latency (see all the comments in podman-systemd about image pull timeouts)

However, the container images and containers can still be updated live if desired, and that's actually expected.  For example, I might update a version of an app *before* the base image's tag.

(a bit more in e.g. https://docs.fedoraproject.org/en-US/bootc/running-containers/#_lifecycling_and_updating_containers_separate )

---

notes:

- *edit* filed https://github.com/containers/podman/issues/22785
- Why not do this by default for all .image files? We could consider that, and having a way to exclude things instead. Either way we should clearly get out of the "magic comment" business and have a proper documented flag, but it'd require changes to podman
- This won't work with anaconda until we fix https://github.com/rhinstaller/anaconda/discussions/5197
- This further increases the problems we have with `/var` 
- bootc-image-builder errors out with: `Error: mkdir /etc/containers/networks: read-only file system` - need to fix podman to not try to create that directory

