### PR TITLE
installdeps: Add libzstd-devel for non-fedora

### DIFF
--- a/ci/installdeps.sh
+++ b/ci/installdeps.sh
@@ -29,5 +29,5 @@ dnf -y install skopeo zstd
 
 case $OS_ID in
     fedora) dnf -y builddep bootc ;;
-    *) dnf -y install openssl-devel ostree-devel cargo ;;
+    *) dnf -y install libzstd-devel openssl-devel ostree-devel cargo ;;
 esac


### PR DESCRIPTION
(For Fedora - https://src.fedoraproject.org/rpms/bootc/pull-request/3)

Required after https://github.com/ostreedev/ostree-rs-ext/pull/628

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
