### PR TITLE
Fix command to move examplepkg log files

### DIFF
--- a/docs/src/building/guidance.md
+++ b/docs/src/building/guidance.md
@@ -166,7 +166,7 @@ to `/var`:
 
 ```dockerfile
 RUN apt|dnf install examplepkg && \
-    mv /opt/examplepkg/logs && /var/log/examplepkg && \
+    mv /opt/examplepkg/logs /var/log/examplepkg && \
     ln -sr /opt/examplepkg/logs /var/log/examplepkg
 ```
 


### PR DESCRIPTION
The extra `&&` breaks the mv command.