### PR TITLE
lib: Drop our once_cell usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,6 @@ dependencies = [
  "liboverdrop",
  "libsystemd",
  "nix 0.28.0",
- "once_cell",
  "openssl",
  "ostree-ext",
  "regex",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -28,7 +28,6 @@ indicatif = "0.17.8"
 libc = "^0.2.154"
 liboverdrop = "0.1.0"
 libsystemd = "0.7"
-once_cell = "1.19"
 openssl = "^0.10.64"
 # TODO drop this in favor of rustix
 nix = { version = "0.28", features = ["ioctl", "sched"] }


### PR DESCRIPTION
The cool kids are using the `std` version for this now.