### PR TITLE
tests/integration: install libzstd-devel

### DIFF
--- a/contrib/packaging/bootc.spec
+++ b/contrib/packaging/bootc.spec
@@ -20,6 +20,7 @@ BuildRequires: zlib-devel
 BuildRequires: ostree-devel
 BuildRequires: openssl-devel
 BuildRequires: systemd-devel
+BuildRequires: libzstd-devel
 
 %description
 %{summary}

--- a/tests/integration/mockbuild.sh
+++ b/tests/integration/mockbuild.sh
@@ -12,7 +12,7 @@ function redprint {
 }
 
 greenprint "📥 Install required packages"
-dnf install -y cargo zstd git openssl-devel ostree-devel rpm-build mock podman skopeo jq
+dnf install -y cargo zstd git libzstd-devel openssl-devel ostree-devel rpm-build mock podman skopeo jq
 cargo install cargo-vendor-filterer
 
 greenprint "⛏ Build archive"


### PR DESCRIPTION
Required to build zstd-sys - https://artifacts.osci.redhat.com/testing-farm/66cab0ec-1653-42ec-b482-a90001dbd65a/work-awskhuoovz0/plans/install-upgrade/aws/execute/data/guest/default-0/tests/integration/install-upgrade/rpm-build-1/output.txt