### PR TITLE
hack: Add support for installing cloud-init+rsync

### DIFF
--- a/hack/Containerfile
+++ b/hack/Containerfile
@@ -1,6 +1,10 @@
 # Build bootc from the current git into a c9s-bootc container image.
 # Use e.g. --build-arg=base=quay.io/fedora/fedora-bootc:40 to target
 # Fedora instead.
+#
+# You can also generate an image with cloud-init and other dependencies
+# with `--build-arg=tmt` which is intended for use particularly via
+# https://tmt.readthedocs.io/en/stable/
 ARG base=quay.io/centos-bootc/centos-bootc:stream9
 FROM $base as build
 COPY hack/build.sh /build.sh
@@ -13,6 +17,9 @@ RUN mkdir -p /build/target/dev-rootfs  # This can hold arbitrary extra content
 RUN --mount=type=cache,target=/build/target --mount=type=cache,target=/var/roothome make test-bin-archive && mkdir -p /out && cp target/bootc.tar.zst /out
 
 FROM $base
+ARG variant=
+COPY hack/provision-derived.sh /tmp
+RUN /tmp/provision-derived.sh "$variant" && rm -f /tmp/*.sh
 COPY --from=build /out/bootc.tar.zst /tmp
 COPY --from=build /build/target/dev-rootfs/ /
 RUN tar -C / --zstd -xvf /tmp/bootc.tar.zst && rm -vf /tmp/*

--- a/hack/provision-derived.sh
+++ b/hack/provision-derived.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -xeu
+case "$1" in
+    tmt)
+      # tmt wants rsync
+      dnf -y install cloud-init rsync && dnf clean all
+      ln -s ../cloud-init.target /usr/lib/systemd/system/default.target.wants
+      # And tmt wants to write to /usr/local/bin
+      rm /usr/local -rf && ln -sr /var/usrlocal /usr/local && mkdir -p /var/usrlocal/bin
+      ;;
+    "") echo "No variant" 
+      ;;
+    *) 
+      echo "Unknown variant: $1" exit 1
+      ;;
+esac


### PR DESCRIPTION
These are things that https://tmt.readthedocs.io/en/stable/ wants, and the goal is to support running under tmt more directly.

Part of https://github.com/containers/bootc/issues/543

With this I can run:

```
provision:
  how: virtual
  image: /home/walters/src/github/containers/bootc/target/testbootc-cloud.qcow2
summary: Basic smoke test
execute:
    how: tmt
    script: bootc status
```