### PR TITLE
status: Use prepare_for_write instead of require_root

### DIFF
--- a/lib/src/status.rs
+++ b/lib/src/status.rs
@@ -305,7 +305,7 @@ pub(crate) async fn status(opts: super::cli::StatusOpts) -> Result<()> {
     let host = if !Utf8Path::new("/run/ostree-booted").try_exists()? {
         Default::default()
     } else {
-        crate::cli::require_root()?;
+        crate::cli::prepare_for_write().await?;
         let sysroot = super::cli::get_locked_sysroot().await?;
         let booted_deployment = sysroot.booted_deployment();
         let (_deployments, host) = get_status(&sysroot, booted_deployment.as_ref())?;

--- a/tests/integration/playbooks/check-system.yaml
+++ b/tests/integration/playbooks/check-system.yaml
@@ -133,13 +133,13 @@
       shell: findmnt -r -o OPTIONS -n /sysroot | awk -F "," '{print $1}'
       register: result_sysroot_mount_status
 
-    - name: /sysroot should be mount with rw permission
+    - name: /sysroot should be mount with ro permission
       block:
         - assert:
             that:
-              - result_sysroot_mount_status.stdout == "rw"
-            fail_msg: "/sysroot is not mounted with rw permission"
-            success_msg: "/sysroot is mounted with rw permission"
+              - result_sysroot_mount_status.stdout == "ro"
+            fail_msg: "/sysroot is not mounted with ro permission"
+            success_msg: "/sysroot is mounted with ro permission"
       always:
         - set_fact:
             total_counter: "{{ total_counter | int + 1 }}"


### PR DESCRIPTION
This prevents /sysroot from switching to being
persistently mounted as rw.