### PR TITLE
build: Install git too

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -10,3 +10,5 @@ t=$(mktemp --suffix .spec)
 curl -L -o ${t} https://src.fedoraproject.org/rpms/bootc/raw/rawhide/f/bootc.spec
 dnf -y builddep "${t}"
 rm -f "${t}"
+# Extra dependencies
+dnf -y install git-core


### PR DESCRIPTION
This must be a regression from the timestamp change: 91ed63caf196dd728fb7c7da10bdce40e2008504

Without this we fail to parse the timestamp and get errors; maybe something else changed.

Of course, we should use a non-Makefile language for this so we get proper error checking.  I may move some of the makefile bits into xtask.rs or so.