### PR TITLE
Fix deprecation warning with rust 1.79.0

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/xtask.rs"
 [dependencies]
 anyhow = "1.0.82"
 camino = "1.1.6"
-chrono = { version = "0.4.38", default_features = false, features = ["std"] }
+chrono = { version = "0.4.38", default-features = false, features = ["std"] }
 fn-error-context = "0.2.1"
 tempfile = "3.10.1"
 mandown = "0.1.3"


### PR DESCRIPTION
New stable gives warning:

`default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
