### PR TITLE
Clippy janitor cleanup

### DIFF
--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -108,7 +108,6 @@ where
     if pb.is_hidden() {
         print!("{}...", msg);
         std::io::stdout().flush().unwrap();
-    } else {
     }
     let r = f.await;
     if pb.is_hidden() {

--- a/tests-integration/src/tests-integration.rs
+++ b/tests-integration/src/tests-integration.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::needless_borrow)]
+#![allow(clippy::needless_borrows_for_generic_args)]
+
 use std::path::PathBuf;
 
 use camino::Utf8PathBuf;


### PR DESCRIPTION
- Allow the needless_borrows in tests-integration
- Remove empty else block

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
