### PR TITLE
install/baseline: Drop separate /dev mount

### DIFF
--- a/lib/src/blockdev.rs
+++ b/lib/src/blockdev.rs
@@ -28,6 +28,7 @@ pub(crate) struct Device {
     pub(crate) label: Option<String>,
     pub(crate) fstype: Option<String>,
     pub(crate) children: Option<Vec<Device>>,
+    pub(crate) size: Option<String>,
 }
 
 impl Device {
@@ -53,7 +54,7 @@ pub(crate) fn wipefs(dev: &Utf8Path) -> Result<()> {
 
 fn list_impl(dev: Option<&Utf8Path>) -> Result<Vec<Device>> {
     let o = Command::new("lsblk")
-        .args(["-J", "-o", "NAME,SERIAL,MODEL,LABEL,FSTYPE"])
+        .args(["-J", "-o", "NAME,SERIAL,MODEL,LABEL,FSTYPE,SIZE"])
         .args(dev)
         .output()?;
     if !o.status.success() {

--- a/lib/src/install/baseline.rs
+++ b/lib/src/install/baseline.rs
@@ -126,9 +126,11 @@ fn mkfs<'a>(
     label: &str,
     opts: impl IntoIterator<Item = &'a str>,
 ) -> Result<uuid::Uuid> {
+    let devinfo = crate::blockdev::list_dev(dev.into())?;
+    let size = devinfo.size.as_deref().unwrap_or("(unknown)");
     let u = uuid::Uuid::new_v4();
     let mut t = Task::new(
-        &format!("Creating {label} filesystem ({fs})"),
+        &format!("Creating {label} filesystem ({fs}) on device {dev} (size={size})"),
         format!("mkfs.{fs}"),
     );
     match fs {


### PR DESCRIPTION
Now that we hard require the host's `/dev`, let's
drop our duplicate `devtmpfs` copy. My main motivation here is I wanted to add some other debugging and trying to invoke e.g. `lsblk` on our temporary copy doesn't work.

With the combination of the host `/dev` plus our invocation of udev settling, we shouldn't hit races.