### PR TITLE
HACKING.md: Clarify `CONTAINER_CONNECTION`

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -27,7 +27,9 @@ accepted!
   While this isn't specific to bootc, you will find the experience of working on Rust
   is greatly aided with use of e.g. [rust-analyzer](https://github.com/rust-lang/rust-analyzer/).
 - An installation of [podman-bootc](https://github.com/containers/podman-bootc-cli)
-  which note on Linux requires that you set up "podman machine".
+  which note on Linux requires that you set up "podman machine". This document
+  assumes you have the environment variable `CONTAINER_CONNECTION` set to your
+  podman machine's name.
 
 ## Ensure you're familiar with a bootc system
 


### PR DESCRIPTION
This commit adds a note to `HACKING.md` to clarify that the environment
variable `CONTAINER_CONNECTION` should be set to the name of the podman
machine.

As an inexperienced user of podman-machine, this detail was not obvious
to me (#611).