### PR TITLE
test: add packit to run tmt integration test

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,9 @@
+---
+jobs:
+  - job: tests
+    trigger: pull_request
+    targets:
+      - fedora-40-x86_64
+    tmt_plan: /build
+    skip_build: true
+    identifier: tmt-integration-test


### PR DESCRIPTION
This PR is a continuous setting of https://github.com/containers/bootc/pull/613. It adds [Packit](https://packit.dev/) to run tmt integration test.

`testing-farm:fedora-40-x86_64:tmt-integration-test` is from [Packit](https://packit.dev/).