### PR TITLE
cli: Make sysroot lock automatically check root + setup mountns

### DIFF
--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -1138,7 +1138,7 @@ async fn prepare_install(
     // Even though we require running in a container, the mounts we create should be specific
     // to this process, so let's enter a private mountns to avoid leaking them.
     if !external_source && std::env::var_os("BOOTC_SKIP_UNSHARE").is_none() {
-        super::cli::ensure_self_unshared_mount_namespace().await?;
+        super::cli::ensure_self_unshared_mount_namespace()?;
     }
 
     setup_sys_mount("efivarfs", EFIVARFS)?;

--- a/lib/src/status.rs
+++ b/lib/src/status.rs
@@ -305,7 +305,6 @@ pub(crate) async fn status(opts: super::cli::StatusOpts) -> Result<()> {
     let host = if !Utf8Path::new("/run/ostree-booted").try_exists()? {
         Default::default()
     } else {
-        crate::cli::prepare_for_write().await?;
         let sysroot = super::cli::get_locked_sysroot().await?;
         let booted_deployment = sysroot.booted_deployment();
         let (_deployments, host) = get_status(&sysroot, booted_deployment.as_ref())?;


### PR DESCRIPTION
Previous to this change, we were always pairing together two functions:

- `prepare_for_write()`
- `get_locked_sysroot()`

Make the latter automatically call the former (and make it private to the cli code).

This will avoid bugs like https://github.com/containers/bootc/pull/595/commits/dcfc7521acaf21072032777b9683796ff710bdfe where we forgot to call the first one and didn't end up with an unshared mountns.

While we're here, drop an unnecessary `async` from these functions, and just in case make `prepare_for_write()` idempotent.