### PR TITLE
tree: Add missing -v /dev:/dev in a few places

### DIFF
--- a/hack/lldb/deploy.sh
+++ b/hack/lldb/deploy.sh
@@ -11,7 +11,7 @@ sudo podman build --build-arg "sshpubkey=$(cat ~/.ssh/id_rsa.pub)" -f Containerf
 mkdir -p ~/.cache/bootc-dev/disks
 rm -f ~/.cache/bootc-dev/disks/lldb.raw
 truncate -s 10G ~/.cache/bootc-dev/disks/lldb.raw
-sudo podman run --pid=host --network=host --privileged --security-opt label=type:unconfined_t -v /var/lib/containers:/var/lib/containers -v ~/.cache/bootc-dev/disks:/output -v /dev:/dev localhost/bootc-lldb bootc install to-disk --via-loopback --generic-image --skip-fetch-check /output/lldb.raw
+sudo podman run --pid=host --network=host --privileged --security-opt label=type:unconfined_t -v /dev:/dev -v /var/lib/containers:/var/lib/containers -v ~/.cache/bootc-dev/disks:/output -v /dev:/dev localhost/bootc-lldb bootc install to-disk --via-loopback --generic-image --skip-fetch-check /output/lldb.raw
 
 # create a new VM in libvirt
 set +e

--- a/tests/integration/image-install-upgrade.sh
+++ b/tests/integration/image-install-upgrade.sh
@@ -150,6 +150,7 @@ case "$IMAGE_TYPE" in
             --privileged \
             --pid=host \
             --security-opt label=type:unconfined_t \
+            -v /dev:/dev \
             -v /var/lib/containers:/var/lib/containers \
             -v /dev:/dev \
             -v .:/output \

--- a/tests/integration/playbooks/install.yaml
+++ b/tests/integration/playbooks/install.yaml
@@ -83,6 +83,7 @@
          --rm \
          --privileged \
          --pid=host \
+         -v /dev:/dev \
          -v /:/target \
          -v /var/lib/containers:/var/lib/containers \
          --security-opt label=type:unconfined_t \


### PR DESCRIPTION
We're really going to need to switch over to having the container do dynamic mounts; cc https://github.com/containers/bootc/issues/380#issuecomment-1983721453

Just noticed this missing in one place, and found others with a grep.

Right now we do operate without, but it can be racier.