### PR TITLE
Release 0.1.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "bootc-lib"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anstream",
  "anstyle",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT OR Apache-2.0"
 name = "bootc-lib"
 readme = "README.md"
 repository = "https://github.com/containers/bootc"
-version = "0.1.11"
+version = "0.1.12"
 rust-version = "1.75.0"
 build = "build.rs"
 


### PR DESCRIPTION
# Release 0.1.12

## New features

Added support for configuring kernel arguments in container builds via the new `/usr/lib/bootc/kargs.d` file; these kernel arguments can be changed "day 2" via container updates. More in https://containers.github.io/bootc/building/kernel-arguments.html

New subcommand `bootc container lint` that can be used in container builds via e.g. `RUN bootc container lint`. This is intended to be a cheap command to run that will detect at build time some common problems.

## Other changes

- A variety of improvements to the documentation landed
- This release includes changes to the default `install to-disk` code and partitioning layout in preparation for supporting s390x, among other architectures.

## Internals

- Significant work on testing landed, with more to come; this should increase velocity and confidence.

---


Raw git log:

```
Bram Mertens (1):
      Fix command to move examplepkg log files

Chris Kyrouac (4):
      hack: Add remote lldb utilities to hack dir
      upgrade: More detailed rpm-ostree modification error msg
      status: Use prepare_for_write instead of require_root
      upgrade: Add error message when staged deployment is incompatible

Colin Walters (41):
      docs/install: A few changes
      docs: Clarify mutability at build vs runtime
      hack: Also support --build-arg=base=<fedora>
      lib: Run `cargo fmt`
      install: Add a spinner for container deployment
      install: Be verbose for EFI creation and bootloader install
      bootloader: Drop --src-root /
      Move install tests shell script into Rust
      ci: Clean up fedora CI
      cli: Check for container before root
      cli: Check for non-ostree container too
      cli: Detect non-ostree and error out earlier
      secrets: Doc credential helper
      tests: Drop `internal-testing-api`, move to tests-integration
      install: Explicitly label .ostree.cfs
      docs: Describe how to configure insecure registries
      Drop unused serde_with
      build: Fetch latest spec from Fedora
      Update to ostree-ext 0.14.0, gvariant 0.5.0
      lib: Drop our once_cell usage
      ci: Fully test file labeling post-install
      lib: Update to ostree-ext 0.14.1
      Makefile: Serialize tarballs reproducibly
      docs: Add HACKING.md
      hack: Add support for installing cloud-init+rsync
      build: Install git too
      install: Move warning after state and possible re-exec
      install: Fix install config kargs + to-filesystem
      install/baseline: Drop separate /dev mount
      install: Show size of target partitions for mkfs
      docs: Even more about how bootc is not a container at runtime
      tests-integration: Add basic local tmt flow
      cli/docs: Expand and clean up clap doctext a bit
      tests-integration: Optimize rebuilds
      cli: Drop a duplicate rootfs open
      cli: Make sysroot lock automatically check root + setup mountns
      install: Add more information on target blockdev
      install/baseline: Drop aarch64 reserved partition
      docs: Make linkcheck optional
      docs/building: Describe kernel arguments
      Release 0.1.12

Eric Curtin (1):
      Add containers-storage to available options

Jiří Stránský (2):
      docs: Fix SELinux policy path
      docs: Mention logical root mount point

John Eckersberg (7):
      ci/docs: Add mdbook-linkcheck
      lib: Run `cargo fmt`
      installdeps: Add libzstd-devel for non-fedora
      tests/integration: install libzstd-devel
      contrib: Add libzstd-devel to specfile
      Fix deprecation warning with rust 1.79.0
      Clippy janitor cleanup

Liora Milbaum (1):
      Renovate config

Luke Yang (2):
      install: Add support for architecture filtering for kargs
      add /usr/lib/bootc/kargs.d support

Omer Tuchfeld (1):
      HACKING.md: Clarify `CONTAINER_CONNECTION`

Platform Engineering Bot (5):
      fix(deps): update auto merged updates
      chore(deps): update all dependencies
      fix(deps): update auto merged updates
      fix(deps): update rust crate clap to v4.5.7
      fix(deps): update rust crate ostree-ext to v0.14.2

Steven Presti (1):
      cli: add `container lint`

Xiaofeng Wang (7):
      test: some updates on test
      test: run tmt integration test on testing farm
      test: install some build dependent packages with dnf builddep bootc
      test: add packit to run tmt integration test
      test: move tmt test log to tmt plan data folder
      test: give tmt vm 20G disk instead of 40G
      test: add aarch64 tmt integration test

Yihuang Yu (5):
      docs: Correct a typo in bootc-install-config.md
      docs: Some updates for SUMMARY.md
      docs: Set bin_name for subcommands and use full title
      docs: Disable "version" option for subcommands
      docs: Delete outdate docs/src/bootc.md

Yohei Ueda (1):
      install: Support non EFI partition format

```