### PR TITLE
install: Clarify /boot (optional) and root mount spec

### DIFF
--- a/docs/src/man/bootc-container-lint.md
+++ b/docs/src/man/bootc-container-lint.md
@@ -23,4 +23,4 @@ part of a build process; it will error if any problems are detected.
 
 # VERSION
 
-v0.1.11
+v0.1.12

--- a/docs/src/man/bootc-container.md
+++ b/docs/src/man/bootc-container.md
@@ -30,4 +30,4 @@ bootc-container-help(8)
 
 # VERSION
 
-v0.1.11
+v0.1.12

--- a/docs/src/man/bootc-edit.md
+++ b/docs/src/man/bootc-edit.md
@@ -36,4 +36,4 @@ Only changes to the \`spec\` section are honored.
 
 # VERSION
 
-v0.1.11
+v0.1.12

--- a/docs/src/man/bootc-install-print-configuration.md
+++ b/docs/src/man/bootc-install-print-configuration.md
@@ -2,8 +2,8 @@
 
 bootc-install-print-configuration - Output JSON to stdout that contains
 the merged installation configuration as it may be relevant to calling
-processes using \`install to-filesystem\` that want to honor e.g.
-\`root-fs-type\`
+processes using \`install to-filesystem\` that in particular want to
+discover the desired root filesystem type from the container image
 
 # SYNOPSIS
 
@@ -13,7 +13,8 @@ processes using \`install to-filesystem\` that want to honor e.g.
 
 Output JSON to stdout that contains the merged installation
 configuration as it may be relevant to calling processes using \`install
-to-filesystem\` that want to honor e.g. \`root-fs-type\`.
+to-filesystem\` that in particular want to discover the desired root
+filesystem type from the container image.
 
 At the current time, the only output key is \`root-fs-type\` which is a
 string-valued filesystem name suitable for passing to \`mkfs.\$type\`.
@@ -26,4 +27,4 @@ string-valued filesystem name suitable for passing to \`mkfs.\$type\`.
 
 # VERSION
 
-v0.1.11
+v0.1.12

--- a/docs/src/man/bootc-install-to-disk.md
+++ b/docs/src/man/bootc-install-to-disk.md
@@ -144,4 +144,4 @@ firmware will be skipped
 
 # VERSION
 
-v0.1.11
+v0.1.12

--- a/docs/src/man/bootc-install-to-existing-root.md
+++ b/docs/src/man/bootc-install-to-existing-root.md
@@ -130,4 +130,4 @@ firmware will be skipped
 
 # VERSION
 
-v0.1.11
+v0.1.12

--- a/docs/src/man/bootc-install-to-filesystem.md
+++ b/docs/src/man/bootc-install-to-filesystem.md
@@ -31,13 +31,14 @@ is currently expected to be empty by default.
 :   Source device specification for the root filesystem. For example,
     UUID=2e9f4241-229b-4202-8429-62d2302382e1
 
+If not provided, the UUID of the target filesystem will be used.
+
 **\--boot-mount-spec**=*BOOT_MOUNT_SPEC*
 
 :   Mount specification for the /boot filesystem.
 
-At the current time, a separate /boot is required. This restriction will
-be lifted in future versions. If not specified, the filesystem UUID will
-be used.
+This is optional. If \`/boot\` is detected as a mounted partition, then
+its UUID will be used.
 
 **\--replace**=*REPLACE*
 
@@ -156,4 +157,4 @@ mounting. To override this, use \`\--root-mount-spec\`.
 
 # VERSION
 
-v0.1.11
+v0.1.12

--- a/docs/src/man/bootc-install.md
+++ b/docs/src/man/bootc-install.md
@@ -52,7 +52,8 @@ bootc-install-print-configuration(8)
 
 :   Output JSON to stdout that contains the merged installation
     configuration as it may be relevant to calling processes using
-    \`install to-filesystem\` that want to honor e.g. \`root-fs-type\`
+    \`install to-filesystem\` that in particular want to discover the
+    desired root filesystem type from the container image
 
 bootc-install-help(8)
 
@@ -60,4 +61,4 @@ bootc-install-help(8)
 
 # VERSION
 
-v0.1.11
+v0.1.12

--- a/docs/src/man/bootc-rollback.md
+++ b/docs/src/man/bootc-rollback.md
@@ -34,4 +34,4 @@ rollback invocation.
 
 # VERSION
 
-v0.1.11
+v0.1.12

--- a/docs/src/man/bootc-status.md
+++ b/docs/src/man/bootc-status.md
@@ -33,4 +33,4 @@ The exact API format is not currently declared stable.
 
 # VERSION
 
-v0.1.11
+v0.1.12

--- a/docs/src/man/bootc-switch.md
+++ b/docs/src/man/bootc-switch.md
@@ -61,4 +61,4 @@ includes a default policy which requires signatures.
 
 # VERSION
 
-v0.1.11
+v0.1.12

--- a/docs/src/man/bootc-upgrade.md
+++ b/docs/src/man/bootc-upgrade.md
@@ -52,4 +52,4 @@ userspace-only restart.
 
 # VERSION
 
-v0.1.11
+v0.1.12

--- a/docs/src/man/bootc-usr-overlay.md
+++ b/docs/src/man/bootc-usr-overlay.md
@@ -39,4 +39,4 @@ unmount\".
 
 # VERSION
 
-v0.1.11
+v0.1.12

--- a/docs/src/man/bootc.md
+++ b/docs/src/man/bootc.md
@@ -72,4 +72,4 @@ bootc-help(8)
 
 # VERSION
 
-v0.1.11
+v0.1.12

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -217,13 +217,15 @@ pub(crate) struct InstallTargetFilesystemOpts {
     pub(crate) root_path: Utf8PathBuf,
 
     /// Source device specification for the root filesystem.  For example, UUID=2e9f4241-229b-4202-8429-62d2302382e1
+    ///
+    /// If not provided, the UUID of the target filesystem will be used.
     #[clap(long)]
     pub(crate) root_mount_spec: Option<String>,
 
     /// Mount specification for the /boot filesystem.
     ///
-    /// At the current time, a separate /boot is required.  This restriction will be lifted in
-    /// future versions.  If not specified, the filesystem UUID will be used.
+    /// This is optional. If `/boot` is detected as a mounted partition, then
+    /// its UUID will be used.
     #[clap(long)]
     pub(crate) boot_mount_spec: Option<String>,
 


### PR DESCRIPTION
install: Clarify /boot (optional) and root mount spec

- /boot has been optional for a while
- Clarify the root uuid

Signed-off-by: Colin Walters <walters@verbum.org>

---

docs: Regenerate markdown

Pick up change in the previous commit, plus a few others.

Signed-off-by: Colin Walters <walters@verbum.org>

---

