### PR TITLE
status: Add explicit `--format` argument

### DIFF
--- a/docs/src/man/bootc-status.md
+++ b/docs/src/man/bootc-status.md
@@ -4,7 +4,7 @@ bootc-status - Display status
 
 # SYNOPSIS
 
-**bootc status** \[**\--json**\] \[**\--booted**\]
+**bootc status** \[**\--format**\] \[**\--booted**\]
 \[**-h**\|**\--help**\]
 
 # DESCRIPTION
@@ -19,9 +19,16 @@ The exact API format is not currently declared stable.
 
 # OPTIONS
 
-**\--json**
+**\--format**=*FORMAT*
 
-:   Output in JSON format
+:   The output format\
+
+\
+*Possible values:*
+
+> -   yaml: Output in YAML format
+>
+> -   json: Output in JSON format
 
 **\--booted**
 

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -12,6 +12,7 @@ use camino::Utf8PathBuf;
 use cap_std_ext::cap_std;
 use cap_std_ext::cap_std::fs::Dir;
 use clap::Parser;
+use clap::ValueEnum;
 use fn_error_context::context;
 use ostree::gio;
 use ostree_container::store::PrepareResult;
@@ -107,12 +108,27 @@ pub(crate) struct EditOpts {
     pub(crate) quiet: bool,
 }
 
+#[derive(Debug, Clone, ValueEnum, PartialEq, Eq)]
+#[clap(rename_all = "lowercase")]
+pub(crate) enum OutputFormat {
+    /// Output in YAML format.
+    YAML,
+    /// Output in JSON format.
+    JSON,
+}
+
 /// Perform an status operation
 #[derive(Debug, Parser, PartialEq, Eq)]
 pub(crate) struct StatusOpts {
     /// Output in JSON format.
-    #[clap(long)]
+    ///
+    /// Superceded by the `format` option.
+    #[clap(long, hide = true)]
     pub(crate) json: bool,
+
+    /// The output format.
+    #[clap(long)]
+    pub(crate) format: Option<OutputFormat>,
 
     /// Only display status for the booted deployment.
     #[clap(long)]
@@ -773,6 +789,7 @@ fn test_parse_opts() {
         Opt::parse_including_static(["bootc", "status"]),
         Opt::Status(StatusOpts {
             json: false,
+            format: None,
             booted: false
         })
     ));

--- a/tests/booted/001-test-status.nu
+++ b/tests/booted/001-test-status.nu
@@ -1,8 +1,10 @@
 use std assert
 use tap.nu
 
-tap begin "verify bootc status --json looks sane"
+tap begin "verify bootc status output formats"
 
 let st = bootc status --json | from json
+assert equal $st.apiVersion org.containers.bootc/v1alpha1
+let st = bootc status --format=yaml | from yaml
 assert equal $st.apiVersion org.containers.bootc/v1alpha1
 tap ok


### PR DESCRIPTION
Prep for adding `--format=human` for example. But this is also useful for anything that explicitly wants to consume YAML today.