### PR TITLE
tree-wide: rustfmt with `group_imports = "StdExternalCrate"`

### DIFF
--- a/lib/src/blockdev.rs
+++ b/lib/src/blockdev.rs
@@ -1,11 +1,3 @@
-use crate::install::run_in_host_mountns;
-use crate::task::Task;
-use anyhow::{anyhow, Context, Result};
-use camino::{Utf8Path, Utf8PathBuf};
-use fn_error_context::context;
-use nix::errno::Errno;
-use regex::Regex;
-use serde::Deserialize;
 use std::collections::HashMap;
 use std::env;
 use std::fs::File;
@@ -13,6 +5,16 @@ use std::os::unix::io::AsRawFd;
 use std::path::Path;
 use std::process::Command;
 use std::sync::OnceLock;
+
+use anyhow::{anyhow, Context, Result};
+use camino::{Utf8Path, Utf8PathBuf};
+use fn_error_context::context;
+use nix::errno::Errno;
+use regex::Regex;
+use serde::Deserialize;
+
+use crate::install::run_in_host_mountns;
+use crate::task::Task;
 
 #[derive(Debug, Deserialize)]
 struct DevicesOutput {

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -2,6 +2,11 @@
 //!
 //! Command line tool to manage bootable ostree-based containers.
 
+use std::ffi::OsString;
+use std::io::Seek;
+use std::os::unix::process::CommandExt;
+use std::process::Command;
+
 use anyhow::{Context, Result};
 use camino::Utf8PathBuf;
 use cap_std_ext::cap_std;
@@ -13,10 +18,6 @@ use ostree_container::store::PrepareResult;
 use ostree_ext::container as ostree_container;
 use ostree_ext::keyfileext::KeyFileExt;
 use ostree_ext::ostree;
-use std::ffi::OsString;
-use std::io::Seek;
-use std::os::unix::process::CommandExt;
-use std::process::Command;
 
 use crate::deploy::RequiredHostSpec;
 use crate::lints;

--- a/lib/src/deploy.rs
+++ b/lib/src/deploy.rs
@@ -6,7 +6,6 @@ use std::io::{BufRead, Write};
 
 use anyhow::Ok;
 use anyhow::{anyhow, Context, Result};
-
 use cap_std::fs::{Dir, MetadataExt};
 use cap_std_ext::cap_std;
 use cap_std_ext::dirext::CapStdExtDirExt;

--- a/lib/src/docgen.rs
+++ b/lib/src/docgen.rs
@@ -2,11 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use std::fs::OpenOptions;
+use std::io::Write;
+
 use anyhow::{Context, Result};
 use camino::Utf8Path;
 use clap::{Command, CommandFactory};
-use std::fs::OpenOptions;
-use std::io::Write;
 
 pub fn generate_manpages(directory: &Utf8Path) -> Result<()> {
     generate_one(directory, crate::cli::Opt::command())

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -28,14 +28,13 @@ use cap_std_ext::cap_std;
 use cap_std_ext::prelude::CapStdExtDirExt;
 use chrono::prelude::*;
 use clap::ValueEnum;
-use ostree_ext::oci_spec;
-use rustix::fs::{FileTypeExt, MetadataExt as _};
-
 use fn_error_context::context;
 use ostree::gio;
 use ostree_ext::container as ostree_container;
+use ostree_ext::oci_spec;
 use ostree_ext::ostree;
 use ostree_ext::prelude::Cast;
+use rustix::fs::{FileTypeExt, MetadataExt as _};
 use serde::{Deserialize, Serialize};
 
 use self::baseline::InstallBlockDeviceOpts;

--- a/lib/src/kargs.rs
+++ b/lib/src/kargs.rs
@@ -1,15 +1,14 @@
 use anyhow::Ok;
 use anyhow::Result;
-
-use crate::deploy::ImageState;
 use ostree::gio;
 use ostree_ext::ostree;
 use ostree_ext::ostree::Deployment;
 use ostree_ext::prelude::Cast;
 use ostree_ext::prelude::FileEnumeratorExt;
 use ostree_ext::prelude::FileExt;
-
 use serde::Deserialize;
+
+use crate::deploy::ImageState;
 
 #[derive(Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]

--- a/lib/src/lsm.rs
+++ b/lib/src/lsm.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "install")]
 use std::io::Write;
+use std::os::fd::AsRawFd;
 use std::os::unix::process::CommandExt;
 use std::path::Path;
 use std::process::Command;
@@ -17,7 +18,6 @@ use gvariant::{aligned_bytes::TryAsAligned, Marker, Structure};
 use ostree_ext::gio;
 use ostree_ext::ostree;
 use rustix::fd::AsFd;
-use std::os::fd::AsRawFd;
 
 /// The mount path for selinux
 #[cfg(feature = "install")]

--- a/lib/src/status.rs
+++ b/lib/src/status.rs
@@ -1,7 +1,5 @@
 use std::collections::VecDeque;
 
-use crate::spec::{BootEntry, BootOrder, Host, HostSpec, HostStatus, HostType, ImageStatus};
-use crate::spec::{ImageReference, ImageSignature};
 use anyhow::{Context, Result};
 use camino::Utf8Path;
 use fn_error_context::context;
@@ -13,6 +11,9 @@ use ostree_ext::oci_spec;
 use ostree_ext::oci_spec::image::ImageConfiguration;
 use ostree_ext::ostree;
 use ostree_ext::sysroot::SysrootLock;
+
+use crate::spec::{BootEntry, BootOrder, Host, HostSpec, HostStatus, HostType, ImageStatus};
+use crate::spec::{ImageReference, ImageSignature};
 
 impl From<ostree_container::SignatureSource> for ImageSignature {
     fn from(sig: ostree_container::SignatureSource) -> Self {


### PR DESCRIPTION
We were inconsistent here; I prefer this `StdExternalCrate` style. Unfortunately it's not stabilized, but this is a manual run with current nightly rustfmt. On the positive side, rustfmt will preserve this ordering in the future.