### PR TITLE
kargs: Various cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,7 @@ dependencies = [
  "serde_ignored",
  "serde_json",
  "serde_yaml",
+ "similar-asserts",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -200,6 +201,17 @@ dependencies = [
  "tracing",
  "uuid",
  "xshell",
+]
+
+[[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -1794,6 +1806,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640"
+dependencies = [
+ "bstr",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "similar-asserts"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e041bb827d1bfca18f213411d51b665309f1afb37a04a5d1464530e13779fc0f"
+dependencies = [
+ "console",
+ "similar",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2180,6 +2212,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"

--- a/hack/Containerfile
+++ b/hack/Containerfile
@@ -25,7 +25,7 @@ RUN /tmp/provision-derived.sh "$variant" && rm -f /tmp/*.sh
 COPY hack/install-test-configs/* /usr/lib/bootc/install/
 # Inject our built code
 COPY --from=build /out/bootc.tar.zst /tmp
-RUN tar -C / --zstd -xvf /tmp/bootc.tar.zst && rm -vf /tmp/*
+RUN tar -C / --zstd -xvf /tmp/bootc.tar.zst && rm -vrf /tmp/*
 # Also copy over arbitrary bits from the target root
 COPY --from=build /build/target/dev-rootfs/ /
 # Test our own linting

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -46,6 +46,9 @@ toml = "0.8.12"
 xshell = { version = "0.2.6", optional = true }
 uuid = { version = "1.8.0", features = ["v4"] }
 
+[dev-dependencies]
+similar-asserts = { version = "1.5.0" }
+
 [features]
 default = ["install"]
 # This feature enables `bootc install`.  Disable if you always want to use an external installer.

--- a/lib/src/kargs.rs
+++ b/lib/src/kargs.rs
@@ -64,9 +64,8 @@ pub(crate) fn get_kargs(
     // Get the running kargs of the booted system
     if let Some(bootconfig) = ostree::Deployment::bootconfig(booted_deployment) {
         if let Some(options) = ostree::BootconfigParser::get(&bootconfig, "options") {
-            let options: Vec<&str> = options.split_whitespace().collect();
-            let mut options: Vec<String> = options.into_iter().map(|s| s.to_string()).collect();
-            kargs.append(&mut options);
+            let options = options.split_whitespace().map(|s| s.to_owned());
+            kargs.extend(options);
         }
     };
 

--- a/lib/src/kargs.rs
+++ b/lib/src/kargs.rs
@@ -72,7 +72,7 @@ pub(crate) fn get_kargs(
 
     // Get the kargs in kargs.d of the booted system
     let root = &cap_std::fs::Dir::open_ambient_dir("/", cap_std::ambient_authority())?;
-    let mut existing_kargs: Vec<String> = get_kargs_in_root(root, sys_arch)?;
+    let existing_kargs: Vec<String> = get_kargs_in_root(root, sys_arch)?;
 
     // Get the kargs in kargs.d of the pending image
     let mut remote_kargs: Vec<String> = vec![];
@@ -83,7 +83,7 @@ pub(crate) fn get_kargs(
         .expect("downcast");
     if !fetched_tree.query_exists(cancellable) {
         // if the kargs.d directory does not exist in the fetched image, return the existing kargs
-        kargs.append(&mut existing_kargs);
+        kargs.extend(existing_kargs);
         return Ok(kargs);
     }
     let queryattrs = "standard::name,standard::type";

--- a/lib/src/kargs.rs
+++ b/lib/src/kargs.rs
@@ -169,3 +169,13 @@ match-architectures = ["x86_64", "aarch64"]
     let parsed_kargs = parse_kargs_toml(&file_content, &sys_arch).unwrap();
     assert_eq!(parsed_kargs, ["console=tty0", "nosmt"]);
 }
+
+#[test]
+/// Verify some error cases
+fn test_invalid() {
+    let test_invalid_extra = r#"kargs = ["console=tty0", "nosmt"]\nfoo=bar"#;
+    assert!(parse_kargs_toml(test_invalid_extra, "x86_64").is_err());
+
+    let test_missing = r#"foo=bar"#;
+    assert!(parse_kargs_toml(test_missing, "x86_64").is_err());
+}

--- a/lib/src/kargs.rs
+++ b/lib/src/kargs.rs
@@ -143,19 +143,15 @@ pub(crate) fn get_kargs(
 /// vector of kernel arguments. Architecture matching is performed using
 /// `sys_arch`.
 fn parse_kargs_toml(contents: &str, sys_arch: &str) -> Result<Vec<String>> {
-    let mut de: Config = toml::from_str(contents)?;
-    let mut parsed_kargs: Vec<String> = vec![];
+    let de: Config = toml::from_str(contents)?;
     // if arch specified, apply kargs only if the arch matches
     // if arch not specified, apply kargs unconditionally
-    match de.match_architectures {
-        None => parsed_kargs = de.kargs,
-        Some(match_architectures) => {
-            if match_architectures.iter().any(|s| s == sys_arch) {
-                parsed_kargs.append(&mut de.kargs);
-            }
-        }
-    }
-    Ok(parsed_kargs)
+    let matched = de
+        .match_architectures
+        .map(|arches| arches.iter().any(|s| s == sys_arch))
+        .unwrap_or(true);
+    let r = if matched { de.kargs } else { Vec::new() };
+    Ok(r)
 }
 
 #[test]


### PR DESCRIPTION
No functional changes intended; just prep for further work.

---

kargs: parser cleanups

- Accept &str vs owned String, allowing dropping unnecessary `clone`
- It isn't parsing a file necessarily, just a string buffer, so rename
  it
- Drop unnecessary `pub`
- Add doc comment
- Add error context to callers to be clear *which* file we failed
  to parse

Signed-off-by: Colin Walters <walters@verbum.org>

---

kargs: Add a few more unit tests

Signed-off-by: Colin Walters <walters@verbum.org>

---

kargs: Parse booted kargs via cap-std, not liboverdrop

liboverdrop isn't helpful here because I don't think we want
or need right now to actually support things like having a file
in `/etc` or `/run` override the kargs. Especially for `/run`
there's no dynamic runtime state.

No functional changes intended, just prep for more work.

---

It *might* in theory be useful for someone to have `/etc`
overrides, but since we weren't actually doing that today, don't
pretend we might by using liboverdrop but not passing `/etc` to
it.

Using cap-std here makes it easier to unit test safely.
(Although, liboverdrop really should grow an optional feature
 to use cap-std)

Signed-off-by: Colin Walters <walters@verbum.org>

---

kargs: Drop unnecessary cloning for sys_arch

Since the function accepts a `&str`, drop the unnecessary cloning.

Signed-off-by: Colin Walters <walters@verbum.org>

---

kargs: Drop unnecessary `mut`

By passing ownership of the vector here we don't need to make
it `mut`able.

Signed-off-by: Colin Walters <walters@verbum.org>

---

kargs: Drop unnecessary allocation and `mut`

We can just pass the iterator directly to `extend`.

Signed-off-by: Colin Walters <walters@verbum.org>

---

kargs: Minor code reordering

No functional changes, but it's clearer to have the `remote_kargs`
definition below where we do the short-circuit.

Signed-off-by: Colin Walters <walters@verbum.org>

---

