### PR TITLE
install: Pick up kargs.d kernel arguments too

### DIFF
--- a/hack/Containerfile
+++ b/hack/Containerfile
@@ -23,6 +23,8 @@ COPY hack/provision-derived.sh /tmp
 RUN /tmp/provision-derived.sh "$variant" && rm -f /tmp/*.sh
 # Also copy in some default install configs we use for testing
 COPY hack/install-test-configs/* /usr/lib/bootc/install/
+# And some test kargs
+COPY hack/test-kargs /usr/lib/bootc/kargs.d/
 # Inject our built code
 COPY --from=build /out/bootc.tar.zst /tmp
 RUN tar -C / --zstd -xvf /tmp/bootc.tar.zst && rm -vrf /tmp/*

--- a/hack/test-kargs/10-test.toml
+++ b/hack/test-kargs/10-test.toml
@@ -1,0 +1,1 @@
+kargs = ["kargsd-test=1", "kargsd-othertest=2"]

--- a/hack/test-kargs/20-test2.toml
+++ b/hack/test-kargs/20-test2.toml
@@ -1,0 +1,1 @@
+kargs = ["testing-kargsd=3"]

--- a/lib/src/kargs.rs
+++ b/lib/src/kargs.rs
@@ -22,7 +22,7 @@ struct Config {
 
 /// Load and parse all bootc kargs.d files in the specified root, returning
 /// a combined list.
-fn get_kargs_in_root(d: &Dir, sys_arch: &str) -> Result<Vec<String>> {
+pub(crate) fn get_kargs_in_root(d: &Dir, sys_arch: &str) -> Result<Vec<String>> {
     // If the directory doesn't exist, that's OK.
     let d = if let Some(d) = d.open_dir_optional("usr/lib/bootc/kargs.d")? {
         d

--- a/tests-integration/src/install.rs
+++ b/tests-integration/src/install.rs
@@ -100,6 +100,11 @@ pub(crate) fn run_alongside(image: &str, mut testargs: libtest_mimic::Arguments)
                     "sudo /bin/sh -c 'grep localtestkarg=somevalue /boot/loader/entries/*.conf'"
                 )
                 .run()?;
+                cmd!(
+                    sh,
+                    "sudo /bin/sh -c 'grep testing-kargsd=3 /boot/loader/entries/*.conf'"
+                )
+                .run()?;
                 let deployment = &find_deployment_root()?;
                 let cwd = sh.push_dir(format!("/proc/self/fd/{}", deployment.as_raw_fd()));
                 cmd!(


### PR DESCRIPTION

This was a rather important miss; we need to pick
up the kargs.d files when doing a `bootc install` too.

Signed-off-by: Colin Walters <walters@verbum.org>

---

