### PR TITLE
tree-wide: Convert to let-else syntax

### DIFF
--- a/lib/src/blockdev.rs
+++ b/lib/src/blockdev.rs
@@ -122,9 +122,7 @@ impl LoopbackDevice {
     // Shared backend for our `close` and `drop` implementations.
     fn impl_close(&mut self) -> Result<()> {
         // SAFETY: This is the only place we take the option
-        let dev = if let Some(dev) = self.dev.take() {
-            dev
-        } else {
+        let Some(dev) = self.dev.take() else {
             tracing::trace!("loopback device already deallocated");
             return Ok(());
         };

--- a/lib/src/containerenv.rs
+++ b/lib/src/containerenv.rs
@@ -35,9 +35,7 @@ pub(crate) fn get_container_execution_info(rootfs: &Dir) -> Result<ContainerExec
     for line in f.lines() {
         let line = line?;
         let line = line.trim();
-        let (k, v) = if let Some(v) = line.split_once('=') {
-            v
-        } else {
+        let Some((k, v)) = line.split_once('=') else {
             continue;
         };
         // Assuming there's no quotes here

--- a/lib/src/deploy.rs
+++ b/lib/src/deploy.rs
@@ -401,9 +401,7 @@ fn find_newest_deployment_name(deploysdir: &Dir) -> Result<String> {
             continue;
         }
         let name = ent.file_name();
-        let name = if let Some(name) = name.to_str() {
-            name
-        } else {
+        let Some(name) = name.to_str() else {
             continue;
         };
         dirs.push((name.to_owned(), ent.metadata()?.mtime()));

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -1570,9 +1570,7 @@ pub(crate) async fn install_to_filesystem(
         loop {
             tracing::debug!("Finding parents for {dev}");
             let mut parents = crate::blockdev::find_parent_devices(&dev)?.into_iter();
-            let parent = if let Some(f) = parents.next() {
-                f
-            } else {
+            let Some(parent) = parents.next() else {
                 break;
             };
             if let Some(next) = parents.next() {

--- a/lib/src/kargs.rs
+++ b/lib/src/kargs.rs
@@ -35,9 +35,7 @@ impl Config {
 /// a combined list.
 pub(crate) fn get_kargs_in_root(d: &Dir, sys_arch: &str) -> Result<Vec<String>> {
     // If the directory doesn't exist, that's OK.
-    let d = if let Some(d) = d.open_dir_optional("usr/lib/bootc/kargs.d")? {
-        d
-    } else {
+    let Some(d) = d.open_dir_optional("usr/lib/bootc/kargs.d")? else {
         return Ok(Default::default());
     };
     let mut ret = Vec::new();
@@ -74,9 +72,7 @@ fn get_kargs_from_ostree(
     while let Some(fetched_info) = fetched_iter.next_file(cancellable)? {
         // only read and parse the file if it is a toml file
         let name = fetched_info.name();
-        let name = if let Some(name) = name.to_str() {
-            name
-        } else {
+        let Some(name) = name.to_str() else {
             continue;
         };
         if !Config::filename_matches(name) {

--- a/xtask/src/xtask.rs
+++ b/xtask/src/xtask.rs
@@ -95,9 +95,7 @@ fn manpages(sh: &Shell) -> Result<()> {
     for ent in std::fs::read_dir(extradir)? {
         let ent = ent?;
         let srcpath = ent.path();
-        let extension = if let Some(extension) = srcpath.extension() {
-            extension
-        } else {
+        let Some(extension) = srcpath.extension() else {
             continue;
         };
         if extension != "md" {
@@ -302,9 +300,7 @@ fn impl_srpm(sh: &Shell) -> Result<Utf8PathBuf> {
     for e in std::fs::read_dir(td)? {
         let e = e?;
         let n = e.file_name();
-        let n = if let Some(n) = n.to_str() {
-            n
-        } else {
+        let Some(n) = n.to_str() else {
             continue;
         };
         if n.ends_with(".src.rpm") {


### PR DESCRIPTION
Convert to [let else](https://doc.rust-lang.org/rust-by-example/flow_control/let_else.html) where possible. I've been coding Rust long before it was stable, and my muscle memory has the expanded form.

But the short form is nicer.