### PR TITLE
copr: Use dnf builddep

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,5 +1,6 @@
 srpm:
-	dnf -y install cargo git openssl-devel ostree-devel
+	dnf -y install dnf-utils
+	dnf -y builddep bootc
 	# similar to https://github.com/actions/checkout/issues/760, but for COPR
 	git config --global --add safe.directory '*'
 	cargo install cargo-vendor-filterer


### PR DESCRIPTION
Yet *another* copy of our build dependencies here... The core problem right now is that we embed pre-built manpages as part of the "source"...which means we need all of our build dependencies there.

It's tempting to switch to not generating man pages.