### PR TITLE
Release 0.1.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "bootc-lib"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anstream",
  "anstyle",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT OR Apache-2.0"
 name = "bootc-lib"
 readme = "README.md"
 repository = "https://github.com/containers/bootc"
-version = "0.1.12"
+version = "0.1.13"
 rust-version = "1.75.0"
 build = "build.rs"
 


### PR DESCRIPTION
Supporting `kargs.d` at install time is a critical feature for kernel args.