### PR TITLE
Add HeliumOS to list of distributions using bootc

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ See the [project documentation](https://containers.github.io/bootc/); there
 are also operating systems and distributions using bootc; here are some examples:
 
 - https://docs.fedoraproject.org/en-US/bootc/
+- https://www.heliumos.org/
 
 ## Developing bootc
 


### PR DESCRIPTION
HeliumOS is a new Linux distribution using bootc for immutability.

This PR would add HeliumOS to the list of operating systems and distros using bootc on the readme.