### PR TITLE
copr: Also install git

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,5 +1,5 @@
 srpm:
-	dnf -y install dnf-utils
+	dnf -y install dnf-utils git
 	dnf -y builddep bootc
 	# similar to https://github.com/actions/checkout/issues/760, but for COPR
 	git config --global --add safe.directory '*'


### PR DESCRIPTION
This whole "install all the build tools to make a source rpm" flow rather stinks...

One thing that would help is for me (or someone else) to package cargo-vendor-filterer at some point.