### PR TITLE
status: Add --format-version

### DIFF
--- a/docs/src/man/bootc-container-lint.md
+++ b/docs/src/man/bootc-container-lint.md
@@ -23,4 +23,4 @@ part of a build process; it will error if any problems are detected.
 
 # VERSION
 
-v0.1.12
+v0.1.13

--- a/docs/src/man/bootc-container.md
+++ b/docs/src/man/bootc-container.md
@@ -30,4 +30,4 @@ bootc-container-help(8)
 
 # VERSION
 
-v0.1.12
+v0.1.13

--- a/docs/src/man/bootc-edit.md
+++ b/docs/src/man/bootc-edit.md
@@ -36,4 +36,4 @@ Only changes to the \`spec\` section are honored.
 
 # VERSION
 
-v0.1.12
+v0.1.13

--- a/docs/src/man/bootc-install-print-configuration.md
+++ b/docs/src/man/bootc-install-print-configuration.md
@@ -27,4 +27,4 @@ string-valued filesystem name suitable for passing to \`mkfs.\$type\`.
 
 # VERSION
 
-v0.1.12
+v0.1.13

--- a/docs/src/man/bootc-install-to-disk.md
+++ b/docs/src/man/bootc-install-to-disk.md
@@ -144,4 +144,4 @@ firmware will be skipped
 
 # VERSION
 
-v0.1.12
+v0.1.13

--- a/docs/src/man/bootc-install-to-existing-root.md
+++ b/docs/src/man/bootc-install-to-existing-root.md
@@ -130,4 +130,4 @@ firmware will be skipped
 
 # VERSION
 
-v0.1.12
+v0.1.13

--- a/docs/src/man/bootc-install-to-filesystem.md
+++ b/docs/src/man/bootc-install-to-filesystem.md
@@ -157,4 +157,4 @@ mounting. To override this, use \`\--root-mount-spec\`.
 
 # VERSION
 
-v0.1.12
+v0.1.13

--- a/docs/src/man/bootc-install.md
+++ b/docs/src/man/bootc-install.md
@@ -61,4 +61,4 @@ bootc-install-help(8)
 
 # VERSION
 
-v0.1.12
+v0.1.13

--- a/docs/src/man/bootc-rollback.md
+++ b/docs/src/man/bootc-rollback.md
@@ -34,4 +34,4 @@ rollback invocation.
 
 # VERSION
 
-v0.1.12
+v0.1.13

--- a/docs/src/man/bootc-status.md
+++ b/docs/src/man/bootc-status.md
@@ -4,8 +4,8 @@ bootc-status - Display status
 
 # SYNOPSIS
 
-**bootc status** \[**\--format**\] \[**\--booted**\]
-\[**-h**\|**\--help**\]
+**bootc status** \[**\--format**\] \[**\--format-version**\]
+\[**\--booted**\] \[**-h**\|**\--help**\]
 
 # DESCRIPTION
 
@@ -30,6 +30,13 @@ The exact API format is not currently declared stable.
 >
 > -   json: Output in JSON format
 
+**\--format-version**=*FORMAT_VERSION*
+
+:   The desired format version. There is currently one supported
+    version, which is version \`0\`. Pass this option to explicitly
+    request it; it is possible that multiple versions will be supported
+    in the future
+
 **\--booted**
 
 :   Only display status for the booted deployment
@@ -40,4 +47,4 @@ The exact API format is not currently declared stable.
 
 # VERSION
 
-v0.1.12
+v0.1.13

--- a/docs/src/man/bootc-switch.md
+++ b/docs/src/man/bootc-switch.md
@@ -61,4 +61,4 @@ includes a default policy which requires signatures.
 
 # VERSION
 
-v0.1.12
+v0.1.13

--- a/docs/src/man/bootc-upgrade.md
+++ b/docs/src/man/bootc-upgrade.md
@@ -52,4 +52,4 @@ userspace-only restart.
 
 # VERSION
 
-v0.1.12
+v0.1.13

--- a/docs/src/man/bootc-usr-overlay.md
+++ b/docs/src/man/bootc-usr-overlay.md
@@ -39,4 +39,4 @@ unmount\".
 
 # VERSION
 
-v0.1.12
+v0.1.13

--- a/docs/src/man/bootc.md
+++ b/docs/src/man/bootc.md
@@ -72,4 +72,4 @@ bootc-help(8)
 
 # VERSION
 
-v0.1.12
+v0.1.13

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -130,6 +130,13 @@ pub(crate) struct StatusOpts {
     #[clap(long)]
     pub(crate) format: Option<OutputFormat>,
 
+    /// The desired format version. There is currently one supported
+    /// version, which is version `0`. Pass this option to explicitly
+    /// request it; it is possible that multiple versions will be
+    /// supported in the future.
+    #[clap(long)]
+    pub(crate) format_version: Option<u32>,
+
     /// Only display status for the booted deployment.
     #[clap(long)]
     pub(crate) booted: bool,
@@ -837,7 +844,15 @@ fn test_parse_opts() {
         Opt::Status(StatusOpts {
             json: false,
             format: None,
+            format_version: None,
             booted: false
+        })
+    ));
+    assert!(matches!(
+        Opt::parse_including_static(["bootc", "status", "--format-version=0"]),
+        Opt::Status(StatusOpts {
+            format_version: Some(0),
+            ..
         })
     ));
 }

--- a/lib/src/status.rs
+++ b/lib/src/status.rs
@@ -304,6 +304,10 @@ pub(crate) fn get_status(
 /// Implementation of the `bootc status` CLI command.
 #[context("Status")]
 pub(crate) async fn status(opts: super::cli::StatusOpts) -> Result<()> {
+    match opts.format_version.unwrap_or_default() {
+        0 => {}
+        o => anyhow::bail!("Unsupported format version: {o}"),
+    };
     let host = if !Utf8Path::new("/run/ostree-booted").try_exists()? {
         Default::default()
     } else {

--- a/tests/booted/001-test-status.nu
+++ b/tests/booted/001-test-status.nu
@@ -5,6 +5,8 @@ tap begin "verify bootc status output formats"
 
 let st = bootc status --json | from json
 assert equal $st.apiVersion org.containers.bootc/v1alpha1
+let st = bootc status --json --format-version=0 | from json
+assert equal $st.apiVersion org.containers.bootc/v1alpha1
 let st = bootc status --format=yaml | from yaml
 assert equal $st.apiVersion org.containers.bootc/v1alpha1
 tap ok

--- a/tests/booted/basic.py
+++ b/tests/booted/basic.py
@@ -10,3 +10,7 @@ def test_bootc_status():
     o = subprocess.check_output(["bootc", "status", "--json"])
     st = json.loads(o)
     assert st['apiVersion'] == 'org.containers.bootc/v1alpha1'
+
+def test_bootc_status_invalid_version():
+    o = subprocess.call(["bootc", "status", "--json", "--format-version=42"])
+    assert o != 0


### PR DESCRIPTION

In preparation for us changing the default output of `bootc status`
in the future (cc https://github.com/containers/bootc/issues/518 )
add `--format-version` that people can start using now to explicitly
request the current version.

It's possible that instead of a hard break we still support
outputting the current format for a while.

Signed-off-by: Colin Walters <walters@verbum.org>

---

docs: Regenerate manpage markdown

Signed-off-by: Colin Walters <walters@verbum.org>

---

