### PR TITLE
copr: Use included spec

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,8 +1,8 @@
 srpm:
 	dnf -y install dnf-utils git
-	dnf -y builddep bootc
 	# similar to https://github.com/actions/checkout/issues/760, but for COPR
 	git config --global --add safe.directory '*'
+	dnf -y builddep ./contrib/packaging/bootc.spec
 	cargo install cargo-vendor-filterer
 	cargo xtask package-srpm
 	mv target/*.src.rpm $$outdir


### PR DESCRIPTION
For some reason the copr process uses a f39 root, and we don't have our zstd dependency there.

Hopefully this will the last fix...