### PR TITLE
lib/bootloader: Write to PReP partition on ppc64le

### DIFF
--- a/lib/src/bootloader.rs
+++ b/lib/src/bootloader.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use camino::Utf8Path;
+use camino::{Utf8Path, Utf8PathBuf};
 use fn_error_context::context;
 
 use crate::blockdev::PartitionTable;
@@ -7,6 +7,28 @@ use crate::task::Task;
 
 /// The name of the mountpoint for efi (as a subdirectory of /boot, or at the toplevel)
 pub(crate) const EFI_DIR: &str = "efi";
+pub(crate) const PREPBOOT_GUID: &str = "9E1A2D38-C612-4316-AA26-8B49521E5A8B";
+pub(crate) const PREPBOOT_LABEL: &str = "PowerPC-PReP-boot";
+
+/// Find the device to pass to bootupd. Only on powerpc64 right now
+/// we explicitly find one with a specific label.
+///
+/// This should get fixed once we execute on https://github.com/coreos/bootupd/issues/432
+fn get_bootupd_device(device: &PartitionTable) -> Result<Utf8PathBuf> {
+    #[cfg(target_arch = "powerpc64")]
+    {
+        return device
+            .partitions
+            .iter()
+            .find(|p| p.parttype.as_str() == PREPBOOT_GUID)
+            .ok_or_else(|| {
+                anyhow::anyhow!("Failed to find PReP partition with GUID {PREPBOOT_GUID}")
+            })
+            .map(|dev| dev.node.as_str().into());
+    }
+    #[cfg(not(target_arch = "powerpc64"))]
+    return Ok(device.path().into());
+}
 
 #[context("Installing bootloader")]
 pub(crate) fn install_via_bootupd(
@@ -17,7 +39,8 @@ pub(crate) fn install_via_bootupd(
     let verbose = std::env::var_os("BOOTC_BOOTLOADER_DEBUG").map(|_| "-vvvv");
     // bootc defaults to only targeting the platform boot method.
     let bootupd_opts = (!configopts.generic_image).then_some(["--update-firmware", "--auto"]);
-    let devpath = device.path();
+
+    let devpath = get_bootupd_device(device)?;
     let args = ["backend", "install", "--write-uuid"]
         .into_iter()
         .chain(verbose)

--- a/lib/src/install/baseline.rs
+++ b/lib/src/install/baseline.rs
@@ -261,8 +261,8 @@ pub(crate) fn install_create_rootfs(
             &mut sgdisk.cmd,
             partno,
             "0:+4M",
-            "PowerPC-PReP-boot",
-            Some("9E1A2D38-C612-4316-AA26-8B49521E5A8B"),
+            crate::bootloader::PREPBOOT_LABEL,
+            Some(crate::bootloader::PREPBOOT_GUID),
         );
     } else {
         anyhow::bail!("Unsupported architecture: {}", std::env::consts::ARCH);


### PR DESCRIPTION
    Bootloader code currently writes required data to base/parent
    device (eg /dev/sda). This logic does not work for ppc64le
    architecture as bootloader configuration has to be written
    to PRePboot partition(typically first partition of disk).

    This patch adds code to identify PowerPC-PReP-boot partition
    (for ppc64le architecture) and writes bootloader data to it.
    realpath command is used to identify PReP partition.

    Incase of writing to qcow2 image, first partition of loopback
    device is used as it points to PRePBoot. In order to identify
    loopback device usage the patch introduces a boolean flag to
    filesystem_impl() routine.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>