### PR TITLE
test: Error fix

### DIFF
--- a/tests/booted/002-test-image-pushpull-upgrade.nu
+++ b/tests/booted/002-test-image-pushpull-upgrade.nu
@@ -31,7 +31,6 @@ def initial_build [] {
     let td = mktemp -d
     cd $td
 
-    do --ignore-errors { podman image rm localhost/bootc o+e>| ignore }
     bootc image copy-to-storage
     let img = podman image inspect localhost/bootc | from json
 

--- a/tests/e2e/playbooks/rollback.yaml
+++ b/tests/e2e/playbooks/rollback.yaml
@@ -21,35 +21,13 @@
       wait_for_connection:
         delay: 30
 
+    - name: check bootc status
+      command: bootc status
+      ignore_errors: true
+      become: true
+
     - name: rollback checking
       block:
-        - name: get booted cachedupdate imageDigest
-          shell: bootc status --json | jq -r '.status.booted.cachedUpdate.imageDigest'
-          register: result_booted_cachedupdate_digest
-          become: true
-
-        - name: get rollback image digest
-          shell: bootc status --json | jq -r '.status.rollback.image.imageDigest'
-          register: result_rollback_image_digest
-          become: true
-
-        - name: check booted cachedUpdate and rollback image digest
-          block:
-            - assert:
-                that:
-                  - result_booted_cachedupdate_digest.stdout == result_rollback_image_digest.stdout
-                fail_msg: "rollback failed"
-                success_msg: "rollback passed"
-          always:
-            - set_fact:
-                total_counter: "{{ total_counter | int + 1 }}"
-          rescue:
-            - name: failed count + 1
-              set_fact:
-                failed_counter: "{{ failed_counter | int + 1 }}"
-          when:
-            - air_gapped_dir | default('') == ""
-
         - name: check installed package
           shell: rpm -qa | sort
           register: result_packages


### PR DESCRIPTION
This PR fixed two errors:

1. do not check cachedUpdate.imageDigest in rollback test. The cachedUpdate.imageDigest is always null. We have wget package checking for rollback successful or not.
2. do not delete image before copy it. Fix "ERROR Pushing image: Export: Copying image: No such image" in integration test.