### PR TITLE
blockdev+install updates

### DIFF
--- a/lib/src/blockdev.rs
+++ b/lib/src/blockdev.rs
@@ -29,7 +29,7 @@ pub(crate) struct Device {
     pub(crate) model: Option<String>,
     pub(crate) partlabel: Option<String>,
     pub(crate) children: Option<Vec<Device>>,
-    pub(crate) size: Option<String>,
+    pub(crate) size: u64,
     #[serde(rename = "maj:min")]
     pub(crate) maj_min: Option<String>,
     // NOTE this one is not available on older util-linux, and
@@ -97,7 +97,7 @@ pub(crate) fn wipefs(dev: &Utf8Path) -> Result<()> {
 
 fn list_impl(dev: Option<&Utf8Path>) -> Result<Vec<Device>> {
     let o = Command::new("lsblk")
-        .args(["-J", "-O"])
+        .args(["-J", "-b", "-O"])
         .args(dev)
         .output()?;
     if !o.status.success() {

--- a/lib/src/blockdev.rs
+++ b/lib/src/blockdev.rs
@@ -27,10 +27,18 @@ pub(crate) struct Device {
     pub(crate) name: String,
     pub(crate) serial: Option<String>,
     pub(crate) model: Option<String>,
-    pub(crate) label: Option<String>,
-    pub(crate) fstype: Option<String>,
+    pub(crate) partlabel: Option<String>,
     pub(crate) children: Option<Vec<Device>>,
     pub(crate) size: Option<String>,
+    #[serde(rename = "maj:min")]
+    pub(crate) maj_min: Option<String>,
+    // NOTE this one is not available on older util-linux, and
+    // will also not exist for whole blockdevs (as opposed to partitions).
+    pub(crate) start: Option<u64>,
+
+    // Filesystem-related properties
+    pub(crate) label: Option<String>,
+    pub(crate) fstype: Option<String>,
 }
 
 impl Device {
@@ -56,7 +64,7 @@ pub(crate) fn wipefs(dev: &Utf8Path) -> Result<()> {
 
 fn list_impl(dev: Option<&Utf8Path>) -> Result<Vec<Device>> {
     let o = Command::new("lsblk")
-        .args(["-J", "-o", "NAME,SERIAL,MODEL,LABEL,FSTYPE,SIZE"])
+        .args(["-J", "-O"])
         .args(dev)
         .output()?;
     if !o.status.success() {

--- a/lib/src/bootloader.rs
+++ b/lib/src/bootloader.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use camino::Utf8Path;
 use fn_error_context::context;
 
+use crate::blockdev::Device;
 use crate::task::Task;
 
 /// The name of the mountpoint for efi (as a subdirectory of /boot, or at the toplevel)
@@ -9,18 +10,19 @@ pub(crate) const EFI_DIR: &str = "efi";
 
 #[context("Installing bootloader")]
 pub(crate) fn install_via_bootupd(
-    device: &Utf8Path,
+    device: &Device,
     rootfs: &Utf8Path,
     configopts: &crate::install::InstallConfigOpts,
 ) -> Result<()> {
     let verbose = std::env::var_os("BOOTC_BOOTLOADER_DEBUG").map(|_| "-vvvv");
     // bootc defaults to only targeting the platform boot method.
     let bootupd_opts = (!configopts.generic_image).then_some(["--update-firmware", "--auto"]);
+    let devpath = device.path();
     let args = ["backend", "install", "--write-uuid"]
         .into_iter()
         .chain(verbose)
         .chain(bootupd_opts.iter().copied().flatten())
-        .chain(["--device", device.as_str(), rootfs.as_str()]);
+        .chain(["--device", devpath.as_str(), rootfs.as_str()]);
     Task::new("Running bootupctl to install bootloader", "bootupctl")
         .args(args)
         .verbose()

--- a/lib/src/install/baseline.rs
+++ b/lib/src/install/baseline.rs
@@ -125,7 +125,7 @@ fn mkfs<'a>(
     opts: impl IntoIterator<Item = &'a str>,
 ) -> Result<uuid::Uuid> {
     let devinfo = crate::blockdev::list_dev(dev.into())?;
-    let size = devinfo.size.as_deref().unwrap_or("(unknown)");
+    let size = ostree_ext::glib::format_size(devinfo.size);
     let u = uuid::Uuid::new_v4();
     let mut t = Task::new(
         &format!("Creating {label} filesystem ({fs}) on device {dev} (size={size})"),
@@ -210,12 +210,8 @@ pub(crate) fn install_create_rootfs(
     };
     let serial = device.serial.as_deref().unwrap_or("<unknown>");
     let model = device.model.as_deref().unwrap_or("<unknown>");
-    let size = device
-        .size
-        .as_deref()
-        .ok_or_else(|| anyhow::anyhow!("Missing size for blockdev"))?;
     println!("Block setup: {block_setup}");
-    println!("       Size: {size}",);
+    println!("       Size: {}", device.size);
     println!("     Serial: {serial}");
     println!("      Model: {model}");
 

--- a/lib/src/install/baseline.rs
+++ b/lib/src/install/baseline.rs
@@ -439,9 +439,10 @@ pub(crate) fn install_create_rootfs(
         BlockSetup::Direct => None,
         BlockSetup::Tpm2Luks => Some(luks_name.to_string()),
     };
+    let device_info = crate::blockdev::list_dev(&devpath)?;
     Ok(RootSetup {
         luks_device,
-        device: devpath,
+        device_info,
         rootfs,
         rootfs_fd,
         rootfs_uuid: Some(root_uuid.to_string()),


### PR DESCRIPTION
This series is prep for 

- https://github.com/containers/bootc/pull/665
- https://github.com/containers/bootc/pull/667

---

blockdev: Get more properties

- Add `partlabel` in prep for ppc64le bootloader bits
- Add `maj_min` and `start` which we want for s390x
- Clearly move the filesystesm-related bits to a separate
  section

Signed-off-by: Colin Walters <walters@verbum.org>

---

blockdev: Backfill `start` if missing

This way we continue to support the version of util-linux in C9S
today.

Signed-off-by: Colin Walters <walters@verbum.org>

---

blockdev: Use `-b` for lsblk, hard require size property

I noticed that the JSON format inconsistently uses human-readable
sizes for some properties, but not others. `size` happens to
be one of the ones were it outputs human readable. But I think
we will often want to operate on the raw byte value on our
own, so let's tell lsblk to just give us raw numbers and
do formatting where needed.

While we're here, just hard require the `size` property.
I don't think any block devices can be missing this.

Signed-off-by: Colin Walters <walters@verbum.org>

---

install: Gather blockdev info early in filesystem phase

The bootloader logic in general is going to need to
query the block layout. But especially for ppc64le and s390x
we'll need this data.

Gather it early on as global state so it's accessible
to the entire `install to-filesystem` phase. Note that
we shouldn't be mutating the blockdev setup in
`to-filesystem`.

Signed-off-by: Colin Walters <walters@verbum.org>

---
