### PR TITLE
build-sys: Add `make validate-rust`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Manpage generation
         run: mkdir -p target/man && cargo run --features=docgen -- man --directory target/man
       - name: Clippy (gate on correctness and suspicous)
-        run: cargo clippy -- -D clippy::correctness -D clippy::suspicious
+        run: make validate-rust
   fedora-container-tests:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'control/skip-ci') }}
     runs-on: ubuntu-24.04

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,11 @@ For some bootc install commands, it's simpler to run the lldb-server in a contai
 sudo podman run --pid=host --network=host --privileged --security-opt label=type:unconfined_t -v /var/lib/containers:/var/lib/containers -v /dev:/dev -v .:/output localhost/bootc-lldb lldb-server platform --listen "*:1234" --server
 ```
 
+## Code linting
+
+The `make validate` target runs checks locally that we gate on
+in CI, currently around `cargo fmt` and `cargo clippy`.
+
 ## Running the tests
 
 First, you can run many unit tests with `cargo test`.

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,13 @@ test-bin-archive: all
 test-tmt:
 	cargo xtask test-tmt
 
-validate:
-	cargo fmt
-	cargo clippy
+# Checks extra rust things (formatting and select clippy lints)
+validate-rust:
+	cargo fmt -- --check -l
+	cargo clippy -- -D clippy::correctness -D clippy::suspicious
+.PHONY: validate-rust
+
+validate: validate-rust
 	ruff check
 .PHONY: validate
 


### PR DESCRIPTION
The `make validate-rust` reproduces locally the same checks we run in CI as gating by default; hook it up to the existing `make validate`.