### PR TITLE
install: Use sfdisk, not lsblk

### DIFF
--- a/lib/src/bootloader.rs
+++ b/lib/src/bootloader.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use camino::Utf8Path;
 use fn_error_context::context;
 
-use crate::blockdev::Device;
+use crate::blockdev::PartitionTable;
 use crate::task::Task;
 
 /// The name of the mountpoint for efi (as a subdirectory of /boot, or at the toplevel)
@@ -10,7 +10,7 @@ pub(crate) const EFI_DIR: &str = "efi";
 
 #[context("Installing bootloader")]
 pub(crate) fn install_via_bootupd(
-    device: &Device,
+    device: &PartitionTable,
     rootfs: &Utf8Path,
     configopts: &crate::install::InstallConfigOpts,
 ) -> Result<()> {

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -823,7 +823,7 @@ fn require_skopeo_with_containers_storage() -> Result<()> {
 
 pub(crate) struct RootSetup {
     luks_device: Option<String>,
-    device_info: crate::blockdev::Device,
+    device_info: crate::blockdev::PartitionTable,
     rootfs: Utf8PathBuf,
     rootfs_fd: Dir,
     rootfs_uuid: Option<String>,
@@ -1598,7 +1598,7 @@ pub(crate) async fn install_to_filesystem(
         dev
     };
     tracing::debug!("Backing device: {backing_device}");
-    let device_info = crate::blockdev::list_dev(Utf8Path::new(&backing_device))?;
+    let device_info = crate::blockdev::partitions_of(Utf8Path::new(&backing_device))?;
 
     let rootarg = format!("root={}", root_info.mount_spec);
     let mut boot = if let Some(spec) = fsopts.boot_mount_spec {

--- a/lib/src/install/baseline.rs
+++ b/lib/src/install/baseline.rs
@@ -439,7 +439,7 @@ pub(crate) fn install_create_rootfs(
         BlockSetup::Direct => None,
         BlockSetup::Tpm2Luks => Some(luks_name.to_string()),
     };
-    let device_info = crate::blockdev::list_dev(&devpath)?;
+    let device_info = crate::blockdev::partitions_of(&devpath)?;
     Ok(RootSetup {
         luks_device,
         device_info,


### PR DESCRIPTION
This works around an issue where `lsblk` ends up parsing data cached from udev in `/run/udev`, but we don't have that mounted by default.

Adding a new mount point hard requirement is logistically complicated right now - we will eventually switch
to dynamic mounts with `open_tree` (cc
https://github.com/containers/bootc/issues/380 )
but this is a relatively straightforward workaround.