### PR TITLE
boundimage: Use new RootDir API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std-ext"
-version = "4.0.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f98c66b91a87715bb68b426cc36f9a5a2e0970a4c0adc631aaf06422d4185b"
+checksum = "d0279cf1f7b6cbeeb98e6946e8fea58136f691d4d0aa8c775f4439a05030a481"
 dependencies = [
  "cap-primitives",
  "cap-tempfile",


### PR DESCRIPTION
- This is an abstraction we want to use in multiple places
- It has shared convenience helpers like `read_to_string` which reduce code here