### PR TITLE
 docs: Add experimental section w/`bootc image`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,12 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+# To build the docs locally you can also do e.g.:
+# cargo install mdbook-mermaid
+# cd docs
+# mdbook-mermaid install
+# mdbook serve
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -44,6 +44,10 @@
 - [Filesystem: sysroot](filesystem-sysroot.md)
 - [Container storage](filesystem-storage.md)
 
+# Experimental features
+
+- [bootc image](experimental-bootc-image.md)
+
 # More information
 
 - [Package manager integration](package-managers.md)

--- a/docs/src/experimental-bootc-image.md
+++ b/docs/src/experimental-bootc-image.md
@@ -1,0 +1,28 @@
+# bootc image
+
+Experimental features are subject to change or removal. Please
+do provide feedback on them.
+
+Tracking issue: <https://github.com/containers/bootc/issues/690>
+
+## Using `bootc image copy-to-storage`
+
+This experimental command is intended to aid in [booting local builds](booting-local-builds.md).
+
+Invoking this command will default to copying the booted container image into the `containers-storage:`
+area as used by e.g. `podman`, under the image tag `localhost/bootc` by default. It can
+then be managed independently; used as a base image, pushed to a registry, etc.
+
+Run `bootc image copy-to-storage --help` for more options.
+
+Example workflow:
+
+```
+$ bootc image copy-to-storage
+$ cat Containerfile
+FROM localhost/bootc
+...
+$ podman build -t localhost/bootc-custom .
+$ bootc switch --transport containers-storage localhost/bootc-custom
+```
+


### PR DESCRIPTION
ci: Document building the docs locally

It was slightly less than obvious.

Signed-off-by: Colin Walters <walters@verbum.org>

---

docs: Add experimental section w/`bootc image`

Let's follow a standard operating procedure for our experimental features:

- A github tracking issue
- A documentation section like this one

Signed-off-by: Colin Walters <walters@verbum.org>

---