### PR TITLE
build-sys: Pre-create `kargs.d` and `bound-images.d`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ all:
     
 install:
 	install -D -m 0755 -t $(DESTDIR)$(prefix)/bin target/release/bootc
+	install -d -m 0755 $(DESTDIR)$(prefix)/lib/bootc-experimental/bound-images.d
+	install -d -m 0755 $(DESTDIR)$(prefix)/lib/bootc/kargs.d
 	install -d -m 0755 $(DESTDIR)$(prefix)/lib/systemd/system-generators/
 	ln -f $(DESTDIR)$(prefix)/bin/bootc $(DESTDIR)$(prefix)/lib/systemd/system-generators/bootc-systemd-generator
 	install -d $(DESTDIR)$(prefix)/lib/bootc/install


### PR DESCRIPTION
Let's ensure these directories exist by default, because we want people to drop things there - and having to create the directory in derived images invites typos.