### PR TITLE
build-sys: Generalize manpage bits to `make update-generated`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ validate: validate-rust
 	ruff check
 .PHONY: validate
 
+update-generated:
+	cargo xtask update-generated
+.PHONY: update-generated
+
 vendor:
 	cargo xtask $@
 .PHONY: vendor

--- a/xtask/src/xtask.rs
+++ b/xtask/src/xtask.rs
@@ -19,7 +19,7 @@ fn main() {
 #[allow(clippy::type_complexity)]
 const TASKS: &[(&str, fn(&Shell) -> Result<()>)] = &[
     ("manpages", manpages),
-    ("man2markdown", man2markdown),
+    ("update-generated", update_generated),
     ("package", package),
     ("package-srpm", package_srpm),
     ("spec", spec),
@@ -116,12 +116,13 @@ fn manpages(sh: &Shell) -> Result<()> {
     Ok(())
 }
 
-/// Generate markdown files (converted from the man pages, which are generated
-/// from the Rust sources) into docs/src, which ends up in the rendered
-/// documentation.  This process is currently manual.
-#[context("man2markdown")]
-fn man2markdown(sh: &Shell) -> Result<()> {
+/// Update generated files, such as converting the man pages to markdown.
+/// This process is currently manual.
+#[context("Updating generated files")]
+fn update_generated(sh: &Shell) -> Result<()> {
     manpages(sh)?;
+    // And convert the man pages into markdown, so they can be included
+    // in the docs.
     for ent in std::fs::read_dir("target/man")? {
         let ent = ent?;
         let path = &ent.path();


### PR DESCRIPTION
I plan to add more generated-from-source files, so generalize the target which is currently specialized to manpages.