### PR TITLE
install: Fork `blockdev --rereadpt` instead of internal ioctl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,6 @@ dependencies = [
  "libc",
  "liboverdrop",
  "libsystemd",
- "nix 0.29.0",
  "openssl",
  "ostree-ext",
  "regex",
@@ -315,12 +314,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -1066,7 +1059,7 @@ dependencies = [
  "hmac",
  "libc",
  "log",
- "nix 0.27.1",
+ "nix",
  "nom",
  "once_cell",
  "serde",
@@ -1186,18 +1179,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset",
-]
-
-[[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags 2.4.2",
- "cfg-if",
- "cfg_aliases",
- "libc",
 ]
 
 [[package]]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -29,8 +29,6 @@ libc = { workspace = true }
 liboverdrop = "0.1.0"
 libsystemd = "0.7"
 openssl = "^0.10.64"
-# TODO drop this in favor of rustix
-nix = { version = "0.29", features = ["ioctl", "sched" ] }
 regex = "1.10.4"
 rustix = { "version" = "0.38.34", features = ["thread", "fs", "system", "process"] }
 schemars = { version = "0.8.17", features = ["chrono"] }

--- a/lib/src/install/baseline.rs
+++ b/lib/src/install/baseline.rs
@@ -315,14 +315,10 @@ pub(crate) fn install_create_rootfs(
     tracing::debug!("Created partition table");
 
     // Reread the partition table
-    {
-        let mut f = std::fs::OpenOptions::new()
-            .write(true)
-            .open(&devpath)
-            .with_context(|| format!("opening {devpath}"))?;
-        crate::blockdev::reread_partition_table(&mut f, true)
-            .context("Rereading partition table")?;
-    }
+    Task::new("Reread partition table", "blockdev")
+        .arg("--rereadpt")
+        .arg(devpath.as_str())
+        .run()?;
 
     // Full udev sync; it'd obviously be better to await just the devices
     // we're targeting, but this is a simple coarse hammer.


### PR DESCRIPTION
The `ioctl` to reread the partition table was the last thing pulling in `nix`. Honestly especially in the install path I have no problem forking external binaries, and since we're already depending on util-linux-core for other things like `sfdisk` and `lsblk`, it just makes sense to so here with the command whose entire role in life is to just issue that `ioctl`.

This drops out an older verison of `nix` (which is a fine crate, but again I think `rustix` is nicer). There's a different version pulled in via libsystemd, but we can get to that later.