### PR TITLE
boundimage: A few minor things

### DIFF
--- a/lib/src/boundimage.rs
+++ b/lib/src/boundimage.rs
@@ -34,6 +34,7 @@ pub(crate) fn pull_bound_images(sysroot: &SysrootLock, deployment: &Deployment) 
 #[context("parse bound image spec dir")]
 fn parse_spec_dir(root: &Dir, spec_dir: &str) -> Result<Vec<BoundImage>> {
     let Some(bound_images_dir) = root.open_dir_optional(spec_dir)? else {
+        tracing::debug!("Missing {spec_dir}");
         return Ok(Default::default());
     };
     // And open a view of the dir that uses RESOLVE_IN_ROOT so we
@@ -107,6 +108,7 @@ fn parse_container_file(file_contents: &tini::Ini) -> Result<BoundImage> {
 
 #[context("pull bound images")]
 fn pull_images(_deployment_root: &Dir, bound_images: Vec<BoundImage>) -> Result<()> {
+    tracing::debug!("Pulling bound images: {}", bound_images.len());
     //TODO: do this in parallel
     for bound_image in bound_images {
         let mut task = Task::new("Pulling bound image", "/usr/bin/podman")

--- a/lib/src/boundimage.rs
+++ b/lib/src/boundimage.rs
@@ -6,18 +6,11 @@ use cap_std_ext::dirext::CapStdExtDirExt;
 use fn_error_context::context;
 use ostree_ext::ostree::Deployment;
 use ostree_ext::sysroot::SysrootLock;
-use rustix::fd::BorrowedFd;
 
 const BOUND_IMAGE_DIR: &str = "usr/lib/bootc-experimental/bound-images.d";
 
-// Access the file descriptor for a sysroot
-#[allow(unsafe_code)]
-pub(crate) fn sysroot_fd(sysroot: &ostree_ext::ostree::Sysroot) -> BorrowedFd {
-    unsafe { BorrowedFd::borrow_raw(sysroot.fd()) }
-}
-
 pub(crate) fn pull_bound_images(sysroot: &SysrootLock, deployment: &Deployment) -> Result<()> {
-    let sysroot_fd = sysroot_fd(&sysroot);
+    let sysroot_fd = crate::utils::sysroot_fd(&sysroot);
     let sysroot_fd = Dir::reopen_dir(&sysroot_fd)?;
     let deployment_root_path = sysroot.deployment_dirpath(&deployment);
     let deployment_root = &sysroot_fd.open_dir(&deployment_root_path)?;


### PR DESCRIPTION
boundimage: use utils::sysroot_fd

These landed independently; use the shared helper.

Signed-off-by: Colin Walters <walters@verbum.org>

---

boundimage: Add some module docs

Signed-off-by: Colin Walters <walters@verbum.org>

---

boundimage: Add some tracing::debug

To debug things.

Signed-off-by: Colin Walters <walters@verbum.org>

---