### PR TITLE
install: Warn if we're not installing to gpt

### DIFF
--- a/lib/src/blockdev.rs
+++ b/lib/src/blockdev.rs
@@ -138,10 +138,18 @@ pub(crate) struct Partition {
     pub(crate) name: Option<String>,
 }
 
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum PartitionType {
+    Dos,
+    Gpt,
+    Unknown(String),
+}
+
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
 pub(crate) struct PartitionTable {
-    pub(crate) label: String,
+    pub(crate) label: PartitionType,
     pub(crate) id: String,
     pub(crate) device: String,
     // We're not using these fields

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -1338,6 +1338,18 @@ async fn install_to_filesystem_impl(state: &State, rootfs: &mut RootSetup) -> Re
     // Drop exclusive ownership since we're done with mutation
     let rootfs = &*rootfs;
 
+    match &rootfs.device_info.label {
+        crate::blockdev::PartitionType::Dos => crate::utils::medium_visibility_warning(
+            "Installing to `dos` format partitions is not recommended",
+        ),
+        crate::blockdev::PartitionType::Gpt => {
+            // The only thing we should be using in general
+        }
+        crate::blockdev::PartitionType::Unknown(o) => {
+            crate::utils::medium_visibility_warning(&format!("Unknown partition label {o}"))
+        }
+    }
+
     // We verify this upfront because it's currently required by bootupd
     let boot_uuid = rootfs
         .get_boot_uuid()?


### PR DESCRIPTION
I am not aware of any reason to use anything else; in theory we can leave this up to the OS, but...I think using `dos` format is really probably just a legacy mistake now.

And if we see anything else...well, let's at least warn.