### PR TITLE
spec: Add the new bootc-experimental dir

### DIFF
--- a/contrib/packaging/bootc.spec
+++ b/contrib/packaging/bootc.spec
@@ -31,6 +31,7 @@ BuildRequires: libzstd-devel
 %{_bindir}/bootc
 %{_prefix}/lib/systemd/system-generators/*
 %{_prefix}/lib/bootc
+%{_prefix}/lib/bootc-experimental
 %{_unitdir}/*
 %{_mandir}/man*/bootc*
 


### PR DESCRIPTION
Sadly RPM requires that we explicitly enumerate all the files we ship.