### PR TITLE
boundimage: Use high level `deployment_fd` helper

### DIFF
--- a/lib/src/boundimage.rs
+++ b/lib/src/boundimage.rs
@@ -20,15 +20,9 @@ const BOUND_IMAGE_DIR: &str = "usr/lib/bootc-experimental/bound-images.d";
 
 /// Given a deployment, pull all container images it references.
 pub(crate) fn pull_bound_images(sysroot: &SysrootLock, deployment: &Deployment) -> Result<()> {
-    let sysroot_fd = crate::utils::sysroot_fd(&sysroot);
-    let sysroot_fd = Dir::reopen_dir(&sysroot_fd)?;
-    let deployment_root_path = sysroot.deployment_dirpath(&deployment);
-    let deployment_root = &sysroot_fd.open_dir(&deployment_root_path)?;
-
-    let bound_images = parse_spec_dir(&deployment_root, BOUND_IMAGE_DIR)?;
-    pull_images(deployment_root, bound_images)?;
-
-    Ok(())
+    let deployment_root = &crate::utils::deployment_fd(sysroot, deployment)?;
+    let bound_images = parse_spec_dir(deployment_root, BOUND_IMAGE_DIR)?;
+    pull_images(deployment_root, bound_images)
 }
 
 #[context("parse bound image spec dir")]

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -31,7 +31,6 @@ pub(crate) fn sysroot_fd(sysroot: &ostree::Sysroot) -> BorrowedFd {
 
 // Return a cap-std `Dir` type for a deployment.
 // TODO: in the future this should perhaps actually mount via composefs
-#[allow(unsafe_code)]
 pub(crate) fn deployment_fd(
     sysroot: &ostree::Sysroot,
     deployment: &ostree::Deployment,


### PR DESCRIPTION
utils: Drop unnecessary lint allow

This function doesn't use unsafe anymore.

Signed-off-by: Colin Walters <walters@verbum.org>

---

boundimage: Use high level `deployment_fd` helper

This keeps things even simpler, it's the same thing we're doing
in `kargs.rs`.

Signed-off-by: Colin Walters <walters@verbum.org>

---