### PR TITLE
Bound install time

### DIFF
--- a/lib/src/boundimage.rs
+++ b/lib/src/boundimage.rs
@@ -18,6 +18,17 @@ use ostree_ext::sysroot::SysrootLock;
 /// symbolic links to `.container` or `.image` files.
 const BOUND_IMAGE_DIR: &str = "usr/lib/bootc-experimental/bound-images.d";
 
+/// A subset of data parsed from a `.image` or `.container` file with
+/// the minimal information necessary to fetch the image.
+///
+/// In the future this may be extended to include e.g. certificates or
+/// other pull options.
+#[derive(PartialEq, Eq)]
+struct BoundImage {
+    image: String,
+    auth_file: Option<String>,
+}
+
 /// Given a deployment, pull all container images it references.
 pub(crate) fn pull_bound_images(sysroot: &SysrootLock, deployment: &Deployment) -> Result<()> {
     let deployment_root = &crate::utils::deployment_fd(sysroot, deployment)?;
@@ -115,17 +126,6 @@ fn pull_images(_deployment_root: &Dir, bound_images: Vec<BoundImage>) -> Result<
     }
 
     Ok(())
-}
-
-/// A subset of data parsed from a `.image` or `.container` file with
-/// the minimal information necessary to fetch the image.
-///
-/// In the future this may be extended to include e.g. certificates or
-/// other pull options.
-#[derive(PartialEq, Eq)]
-struct BoundImage {
-    image: String,
-    auth_file: Option<String>,
 }
 
 impl BoundImage {

--- a/lib/src/boundimage.rs
+++ b/lib/src/boundimage.rs
@@ -24,7 +24,7 @@ const BOUND_IMAGE_DIR: &str = "usr/lib/bootc-experimental/bound-images.d";
 /// In the future this may be extended to include e.g. certificates or
 /// other pull options.
 #[derive(PartialEq, Eq)]
-struct BoundImage {
+pub(crate) struct BoundImage {
     image: String,
     auth_file: Option<String>,
 }
@@ -37,7 +37,7 @@ pub(crate) fn pull_bound_images(sysroot: &SysrootLock, deployment: &Deployment) 
 }
 
 #[context("Querying bound images")]
-fn query_bound_images(root: &Dir) -> Result<Vec<BoundImage>> {
+pub(crate) fn query_bound_images(root: &Dir) -> Result<Vec<BoundImage>> {
     let spec_dir = BOUND_IMAGE_DIR;
     let Some(bound_images_dir) = root.open_dir_optional(spec_dir)? else {
         tracing::debug!("Missing {spec_dir}");
@@ -113,7 +113,7 @@ fn parse_container_file(file_contents: &tini::Ini) -> Result<BoundImage> {
 }
 
 #[context("pull bound images")]
-fn pull_images(_deployment_root: &Dir, bound_images: Vec<BoundImage>) -> Result<()> {
+pub(crate) fn pull_images(_deployment_root: &Dir, bound_images: Vec<BoundImage>) -> Result<()> {
     tracing::debug!("Pulling bound images: {}", bound_images.len());
     //TODO: do this in parallel
     for bound_image in bound_images {

--- a/lib/src/boundimage.rs
+++ b/lib/src/boundimage.rs
@@ -32,12 +32,12 @@ struct BoundImage {
 /// Given a deployment, pull all container images it references.
 pub(crate) fn pull_bound_images(sysroot: &SysrootLock, deployment: &Deployment) -> Result<()> {
     let deployment_root = &crate::utils::deployment_fd(sysroot, deployment)?;
-    let bound_images = parse_spec_dir(deployment_root)?;
+    let bound_images = query_bound_images(deployment_root)?;
     pull_images(deployment_root, bound_images)
 }
 
-#[context("parse bound image spec dir")]
-fn parse_spec_dir(root: &Dir) -> Result<Vec<BoundImage>> {
+#[context("Querying bound images")]
+fn query_bound_images(root: &Dir) -> Result<Vec<BoundImage>> {
     let spec_dir = BOUND_IMAGE_DIR;
     let Some(bound_images_dir) = root.open_dir_optional(spec_dir)? else {
         tracing::debug!("Missing {spec_dir}");
@@ -179,12 +179,12 @@ mod tests {
 
         // Empty dir should return an empty vector
         let td = &cap_std_ext::cap_tempfile::TempDir::new(cap_std::ambient_authority())?;
-        let images = parse_spec_dir(td).unwrap();
+        let images = query_bound_images(td).unwrap();
         assert_eq!(images.len(), 0);
 
         td.create_dir_all(BOUND_IMAGE_DIR).unwrap();
         td.create_dir_all(CONTAINER_IMAGE_DIR).unwrap();
-        let images = parse_spec_dir(td).unwrap();
+        let images = query_bound_images(td).unwrap();
         assert_eq!(images.len(), 0);
 
         // Should return BoundImages
@@ -216,7 +216,7 @@ mod tests {
         )
         .unwrap();
 
-        let mut images = parse_spec_dir(td).unwrap();
+        let mut images = query_bound_images(td).unwrap();
         images.sort_by(|a, b| a.image.as_str().cmp(&b.image.as_str()));
         assert_eq!(images.len(), 2);
         assert_eq!(images[0].image, "quay.io/bar/bar:latest");
@@ -225,13 +225,13 @@ mod tests {
         // Invalid symlink should return an error
         td.symlink("./blah", format!("{BOUND_IMAGE_DIR}/blah.image"))
             .unwrap();
-        assert!(parse_spec_dir(td).is_err());
+        assert!(query_bound_images(td).is_err());
 
         // Invalid image contents should return an error
         td.write("error.image", "[Image]\n").unwrap();
         td.symlink_contents("/error.image", format!("{BOUND_IMAGE_DIR}/error.image"))
             .unwrap();
-        assert!(parse_spec_dir(td).is_err());
+        assert!(query_bound_images(td).is_err());
 
         Ok(())
     }


### PR DESCRIPTION
utils: Drop unnecessary lint allow

This function doesn't use unsafe anymore.

Signed-off-by: Colin Walters <walters@verbum.org>

---

boundimage: Use high level `deployment_fd` helper

This keeps things even simpler, it's the same thing we're doing
in `kargs.rs`.

Signed-off-by: Colin Walters <walters@verbum.org>

---

boundimage: More struct definition to top

I think it's generally best to have type definitions come before
the code that references them.

Signed-off-by: Colin Walters <walters@verbum.org>

---

boundimage: Drop const parameter

We were always passing this single constant value to the
function; let's just reference it inside the function
and simplify callers.

Signed-off-by: Colin Walters <walters@verbum.org>

---

boundimage: Rename helper function

I think this name is a bit clearer.

Signed-off-by: Colin Walters <walters@verbum.org>

---

boundimage: Make helpers `pub(crate)`

Prep for using them in the install path.

Signed-off-by: Colin Walters <walters@verbum.org>

---

install: Pull bound images by default

Unless overridden by a CLI option, in which case they will
likely be pulled on firstboot.

Signed-off-by: Colin Walters <walters@verbum.org>

---