### PR TITLE
boundimages: Switch from bootc-experimental to bootc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all:
     
 install:
 	install -D -m 0755 -t $(DESTDIR)$(prefix)/bin target/release/bootc
-	install -d -m 0755 $(DESTDIR)$(prefix)/lib/bootc-experimental/bound-images.d
+	install -d -m 0755 $(DESTDIR)$(prefix)/lib/bootc/bound-images.d
 	install -d -m 0755 $(DESTDIR)$(prefix)/lib/bootc/kargs.d
 	install -d -m 0755 $(DESTDIR)$(prefix)/lib/systemd/system-generators/
 	ln -f $(DESTDIR)$(prefix)/bin/bootc $(DESTDIR)$(prefix)/lib/systemd/system-generators/bootc-systemd-generator

--- a/contrib/packaging/bootc.spec
+++ b/contrib/packaging/bootc.spec
@@ -31,7 +31,6 @@ BuildRequires: libzstd-devel
 %{_bindir}/bootc
 %{_prefix}/lib/systemd/system-generators/*
 %{_prefix}/lib/bootc
-%{_prefix}/lib/bootc-experimental
 %{_unitdir}/*
 %{_mandir}/man*/bootc*
 

--- a/docs/src/experimental-logically-bound-images.md
+++ b/docs/src/experimental-logically-bound-images.md
@@ -14,7 +14,7 @@ This experimental feature enables an association of container "app" images to a 
 
 ## Using logically bound images
 
-Each image is defined in a [Podman Quadlet](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html) `.image` or `.container` file. An image is selected to be bound by creating a symlink in the `/usr/lib/bootc-experimental/bound-images.d` directory pointing to a `.image` or `.container` file. With these defined, during a `bootc upgrade` or `bootc switch` the bound images defined in the new bootc image will be automatically pulled via podman.
+Each image is defined in a [Podman Quadlet](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html) `.image` or `.container` file. An image is selected to be bound by creating a symlink in the `/usr/lib/bootc/bound-images.d` directory pointing to a `.image` or `.container` file. With these defined, during a `bootc upgrade` or `bootc switch` the bound images defined in the new bootc image will be automatically pulled via podman.
 
 An example Containerfile
 
@@ -24,8 +24,8 @@ FROM quay.io/myorg/myimage:latest
 COPY ./my-app.image /usr/share/containers/systemd/my-app.image
 COPY ./another-app.container /usr/share/containers/systemd/another-app.container
 
-RUN ln -s /usr/share/containers/systemd/my-app.image /usr/lib/bootc-experimental/bound-images.d/my-app.image && \
-    ln -s /usr/share/containers/systemd/my-app.image /usr/lib/bootc-experimental/bound-images.d/my-app.image
+RUN ln -s /usr/share/containers/systemd/my-app.image /usr/lib/bootc/bound-images.d/my-app.image && \
+    ln -s /usr/share/containers/systemd/my-app.image /usr/lib/bootc/bound-images.d/my-app.image
 ```
 
 ## Limitations

--- a/lib/src/boundimage.rs
+++ b/lib/src/boundimage.rs
@@ -16,7 +16,7 @@ use ostree_ext::sysroot::SysrootLock;
 
 /// The path in a root for bound images; this directory should only contain
 /// symbolic links to `.container` or `.image` files.
-const BOUND_IMAGE_DIR: &str = "usr/lib/bootc-experimental/bound-images.d";
+const BOUND_IMAGE_DIR: &str = "usr/lib/bootc/bound-images.d";
 
 /// A subset of data parsed from a `.image` or `.container` file with
 /// the minimal information necessary to fetch the image.


### PR DESCRIPTION
This is a stable enough feature to be included in the primary bootc directory.