### PR TITLE
build: move needless_borrow lint allows to be global

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,7 @@ unused_must_use = "forbid"
 # These should only be in local code
 dbg_macro = "deny"
 todo = "deny"
+# These two are in my experience the lints which are most likely
+# to trigger, and among the least valuable to fix.
+needless_borrow = "allow"
+needless_borrows_for_generic_args = "allow"

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -8,10 +8,6 @@
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![cfg_attr(feature = "dox", feature(doc_cfg))]
-// These two are in my experience the lints which are most likely
-// to trigger, and among the least valuable to fix.
-#![allow(clippy::needless_borrow)]
-#![allow(clippy::needless_borrows_for_generic_args)]
 
 mod boundimage;
 pub mod cli;

--- a/tests-integration/src/tests-integration.rs
+++ b/tests-integration/src/tests-integration.rs
@@ -1,6 +1,3 @@
-#![allow(clippy::needless_borrow)]
-#![allow(clippy::needless_borrows_for_generic_args)]
-
 use std::path::PathBuf;
 
 use camino::Utf8PathBuf;


### PR DESCRIPTION
A new instance of this snuck in under xtask, this will make sure it's
covered everywhere going forward.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
