### PR TITLE
install: Correctly set target imgref at pull time

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -549,7 +549,7 @@ async fn upgrade(opts: UpgradeOpts) -> Result<()> {
             }
         }
     } else {
-        let fetched = crate::deploy::pull(repo, imgref, opts.quiet).await?;
+        let fetched = crate::deploy::pull(repo, imgref, None, opts.quiet).await?;
         let staged_digest = staged_image.as_ref().map(|s| s.image_digest.as_str());
         let fetched_digest = fetched.manifest_digest.as_str();
         tracing::debug!("staged: {staged_digest:?}");
@@ -642,7 +642,7 @@ async fn switch(opts: SwitchOpts) -> Result<()> {
     }
     let new_spec = RequiredHostSpec::from_spec(&new_spec)?;
 
-    let fetched = crate::deploy::pull(repo, &target, opts.quiet).await?;
+    let fetched = crate::deploy::pull(repo, &target, None, opts.quiet).await?;
 
     if !opts.retain {
         // By default, we prune the previous ostree ref so it will go away after later upgrades
@@ -700,7 +700,7 @@ async fn edit(opts: EditOpts) -> Result<()> {
         return crate::deploy::rollback(sysroot).await;
     }
 
-    let fetched = crate::deploy::pull(repo, new_spec.image, opts.quiet).await?;
+    let fetched = crate::deploy::pull(repo, new_spec.image, None, opts.quiet).await?;
 
     // TODO gc old layers here
 

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -668,7 +668,7 @@ async fn install_container(
         let spec_imgref = ImageReference::from(src_imageref.clone());
         let repo = &sysroot.repo();
         repo.set_disable_fsync(true);
-        crate::deploy::pull(repo, &spec_imgref, false).await?;
+        crate::deploy::pull(repo, &spec_imgref, Some(&state.target_imgref), false).await?;
         repo.set_disable_fsync(false);
     }
 


### PR DESCRIPTION
We broke `bootc image copy-to-storage` because the change to run a separate pull phase was using the digested (source) pull spec incorrectly. Somehow the deploy phase was picking that up and not also writing the non-digested (target) spec.