### PR TITLE
Fix compiler warning on rust 1.80

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -7,7 +7,6 @@
 // See https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
-#![cfg_attr(feature = "dox", feature(doc_cfg))]
 
 mod boundimage;
 pub mod cli;


### PR DESCRIPTION
This dox/doc_cfg attr looks like it was originally included when bootc
was split off from ostree into its own repo but never actually used
here, so just remove it.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
