### PR TITLE
storage: Two prep changes

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -433,7 +433,7 @@ pub(crate) async fn get_locked_sysroot() -> Result<ostree_ext::sysroot::SysrootL
 #[context("Initializing storage")]
 pub(crate) async fn get_storage() -> Result<crate::store::Storage> {
     let sysroot = get_locked_sysroot().await?;
-    Ok(crate::store::Storage::new(sysroot))
+    crate::store::Storage::new(sysroot)
 }
 
 #[context("Querying root privilege")]

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -610,7 +610,7 @@ async fn initialize_ostree_root(state: &State, root_setup: &RootSetup) -> Result
     let sysroot = ostree::Sysroot::new(Some(&gio::File::for_path(rootfs)));
     sysroot.load(cancellable)?;
     let sysroot = SysrootLock::new_from_sysroot(&sysroot).await?;
-    Ok(Storage::new(sysroot))
+    Storage::new(sysroot)
 }
 
 #[context("Creating ostree deployment")]

--- a/lib/src/store/mod.rs
+++ b/lib/src/store/mod.rs
@@ -48,7 +48,7 @@ impl Deref for Storage {
 }
 
 impl Storage {
-    pub fn new(sysroot: SysrootLock) -> Self {
+    pub fn new(sysroot: SysrootLock) -> Result<Self> {
         let store = match env::var("BOOTC_STORAGE") {
             Ok(val) => crate::spec::Store::from_str(&val, true).unwrap_or_else(|_| {
                 let default = crate::spec::Store::default();
@@ -60,7 +60,7 @@ impl Storage {
 
         let store = load(store);
 
-        Self { sysroot, store }
+        Ok(Self { sysroot, store })
     }
 }
 


### PR DESCRIPTION
install: Rework to use Storage

Prep for https://github.com/containers/bootc/issues/721

Signed-off-by: Colin Walters <walters@verbum.org>

---

storage: Change to return Result

Prep for adding more falliable initialization here.

Signed-off-by: Colin Walters <walters@verbum.org>

---