### PR TITLE
Initialize a containers-storage: owned by bootc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ install:
 	install -D -m 0755 -t $(DESTDIR)$(prefix)/bin target/release/bootc
 	install -d -m 0755 $(DESTDIR)$(prefix)/lib/bootc/bound-images.d
 	install -d -m 0755 $(DESTDIR)$(prefix)/lib/bootc/kargs.d
+	ln -s /sysroot/ostree/bootc/storage $(DESTDIR)$(prefix)/lib/bootc/storage
 	install -d -m 0755 $(DESTDIR)$(prefix)/lib/systemd/system-generators/
 	ln -f $(DESTDIR)$(prefix)/bin/bootc $(DESTDIR)$(prefix)/lib/systemd/system-generators/bootc-systemd-generator
 	install -d $(DESTDIR)$(prefix)/lib/bootc/install

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -430,10 +430,12 @@ pub(crate) async fn get_locked_sysroot() -> Result<ostree_ext::sysroot::SysrootL
     Ok(sysroot)
 }
 
+/// Load global storage state, expecting that we're booted into a bootc system.
 #[context("Initializing storage")]
 pub(crate) async fn get_storage() -> Result<crate::store::Storage> {
+    let global_run = Dir::open_ambient_dir("/run", cap_std::ambient_authority())?;
     let sysroot = get_locked_sysroot().await?;
-    crate::store::Storage::new(sysroot)
+    crate::store::Storage::new(sysroot, &global_run)
 }
 
 #[context("Querying root privilege")]

--- a/lib/src/imgstorage.rs
+++ b/lib/src/imgstorage.rs
@@ -1,0 +1,85 @@
+//! # bootc-managed container storage
+//!
+//! The default storage for this project uses ostree, canonically storing all of its state in
+//! `/sysroot/ostree`.
+//!
+//! This containers-storage: which canonically lives in `/sysroot/ostree/bootc`.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use camino::Utf8Path;
+use cap_std_ext::cap_std::fs::Dir;
+use cap_std_ext::cmdext::CapStdExtCommandExt;
+use cap_std_ext::dirext::CapStdExtDirExt;
+use fn_error_context::context;
+use std::os::fd::OwnedFd;
+
+use crate::task::Task;
+
+/// The path to the storage, relative to the physical system root.
+pub(crate) const SUBPATH: &str = "ostree/bootc/storage";
+/// The path to the "runroot" with transient runtime state; this is
+/// relative to the /run directory
+const RUNROOT: &str = "bootc/storage";
+pub(crate) struct Storage {
+    root: Dir,
+    #[allow(dead_code)]
+    run: Dir,
+}
+
+impl Storage {
+    fn podman_task_in(sysroot: OwnedFd, run: OwnedFd) -> Result<crate::task::Task> {
+        let mut t = Task::new_quiet("podman");
+        // podman expects absolute paths for these, so use /proc/self/fd
+        {
+            let sysroot_fd: Arc<OwnedFd> = Arc::new(sysroot);
+            t.cmd.take_fd_n(sysroot_fd, 3);
+        }
+        {
+            let run_fd: Arc<OwnedFd> = Arc::new(run);
+            t.cmd.take_fd_n(run_fd, 4);
+        }
+        t = t.args(["--root=/proc/self/fd/3", "--runroot=/proc/self/fd/4"]);
+        Ok(t)
+    }
+
+    #[allow(dead_code)]
+    fn podman_task(&self) -> Result<crate::task::Task> {
+        let sysroot = self.root.try_clone()?.into_std_file().into();
+        let run = self.run.try_clone()?.into_std_file().into();
+        Self::podman_task_in(sysroot, run)
+    }
+
+    #[context("Creating imgstorage")]
+    pub(crate) fn create(sysroot: &Dir, run: &Dir) -> Result<Self> {
+        let subpath = Utf8Path::new(SUBPATH);
+        // SAFETY: We know there's a parent
+        let parent = subpath.parent().unwrap();
+        if !sysroot.try_exists(subpath)? {
+            let tmp = format!("{SUBPATH}.tmp");
+            sysroot.remove_all_optional(&tmp)?;
+            sysroot.create_dir_all(parent)?;
+            sysroot.create_dir_all(&tmp).context("Creating tmpdir")?;
+            // There's no explicit API to initialize a containers-storage:
+            // root, simply passing a path will attempt to auto-create it.
+            // We run "podman images" in the new root.
+            Self::podman_task_in(sysroot.open_dir(&tmp)?.into(), run.try_clone()?.into())?
+                .arg("images")
+                .run()?;
+            sysroot
+                .rename(&tmp, sysroot, subpath)
+                .context("Renaming tmpdir")?;
+        }
+        Self::open(sysroot, run)
+    }
+
+    #[context("Opening imgstorage")]
+    pub(crate) fn open(sysroot: &Dir, run: &Dir) -> Result<Self> {
+        let root = sysroot.open_dir(SUBPATH).context(SUBPATH)?;
+        // Always auto-create this if missing
+        run.create_dir_all(RUNROOT)?;
+        let run = run.open_dir(RUNROOT).context(RUNROOT)?;
+        Ok(Self { root, run })
+    }
+}

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -26,6 +26,7 @@ use camino::Utf8PathBuf;
 use cap_std::fs::{Dir, MetadataExt};
 use cap_std_ext::cap_std;
 use cap_std_ext::cap_std::fs_utf8::DirEntry as DirEntryUtf8;
+use cap_std_ext::cap_tempfile::TempDir;
 use cap_std_ext::cmdext::CapStdExtCommandExt;
 use cap_std_ext::prelude::CapStdExtDirExt;
 use chrono::prelude::*;
@@ -322,6 +323,7 @@ pub(crate) struct State {
     pub(crate) root_ssh_authorized_keys: Option<String>,
     /// The root filesystem of the running container
     pub(crate) container_root: Dir,
+    pub(crate) tempdir: TempDir,
 }
 
 impl State {
@@ -342,6 +344,7 @@ impl State {
 
     #[context("Finalizing state")]
     pub(crate) fn consume(self) -> Result<()> {
+        self.tempdir.close()?;
         // If we had invoked `setenforce 0`, then let's re-enable it.
         if let SELinuxFinalState::Enabled(Some(guard)) = self.selinux_state {
             guard.consume()?;
@@ -1001,7 +1004,7 @@ fn ensure_var() -> Result<()> {
 ///  via a custom bwrap container today) and work around it by
 /// mounting a writable transient overlayfs.
 #[context("Ensuring writable /etc")]
-fn ensure_writable_etc_containers() -> Result<()> {
+fn ensure_writable_etc_containers(tempdir: &Dir) -> Result<()> {
     let etc_containers = Utf8Path::new("/etc/containers");
     // If there's no /etc/containers, nothing to do
     if !etc_containers.try_exists()? {
@@ -1010,24 +1013,18 @@ fn ensure_writable_etc_containers() -> Result<()> {
     if rustix::fs::access(etc_containers.as_std_path(), rustix::fs::Access::WRITE_OK).is_ok() {
         return Ok(());
     }
-    // Create a tempdir for the overlayfs upper; right now this is leaked,
-    // but in the case we care about it's into a tmpfs allocated only while
-    // we're running (equivalent to PrivateTmp=yes), so it's not
-    // really a leak.
-    let td = tempfile::tempdir_in("/tmp")?.into_path();
-    let td: &Utf8Path = (td.as_path()).try_into()?;
-    let upper = &td.join("upper");
-    let work = &td.join("work");
-    std::fs::create_dir(upper)?;
-    std::fs::create_dir(work)?;
-    let opts = format!("lowerdir={etc_containers},workdir={work},upperdir={upper}");
-    Task::new(
+    // Create dirs for the overlayfs upper and work in the install-global tmpdir.
+    tempdir.create_dir_all("etc-ovl/upper")?;
+    tempdir.create_dir("etc-ovl/work")?;
+    let opts = format!("lowerdir={etc_containers},workdir=etc-ovl/work,upperdir=etc-ovl/upper");
+    let mut t = Task::new(
         &format!("Mount transient overlayfs for {etc_containers}"),
         "mount",
     )
     .args(["-t", "overlay", "overlay", "-o", opts.as_str()])
-    .arg(etc_containers)
-    .run()?;
+    .arg(etc_containers);
+    t.cmd.cwd_dir(tempdir.try_clone()?);
+    t.run()?;
     Ok(())
 }
 
@@ -1214,9 +1211,14 @@ async fn prepare_install(
         verify_target_fetch(&target_imgref).await?;
     }
 
+    // A bit of basic global state setup
     ensure_var()?;
     setup_tmp_mounts()?;
-    ensure_writable_etc_containers()?;
+    // Allocate a temporary directory we can use in various places to avoid
+    // creating multiple.
+    let tempdir = cap_std_ext::cap_tempfile::TempDir::new(cap_std::ambient_authority())?;
+    // And continue to init global state
+    ensure_writable_etc_containers(&tempdir)?;
 
     // Even though we require running in a container, the mounts we create should be specific
     // to this process, so let's enter a private mountns to avoid leaking them.
@@ -1260,6 +1262,7 @@ async fn prepare_install(
         install_config,
         root_ssh_authorized_keys,
         container_root: rootfs,
+        tempdir,
     });
 
     Ok(state)

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -44,3 +44,4 @@ pub mod spec;
 
 #[cfg(feature = "docgen")]
 mod docgen;
+mod imgstorage;

--- a/tests/booted/010-test-bootc-container-store.nu
+++ b/tests/booted/010-test-bootc-container-store.nu
@@ -1,0 +1,8 @@
+use std assert
+use tap.nu
+
+tap begin "verify bootc-owned container storage"
+
+# This should currently be empty by default...
+podman --storage-opt=additionalimagestore=/usr/lib/bootc/storage images
+tap ok


### PR DESCRIPTION
Depends: https://github.com/containers/bootc/pull/730

---

install: Allocate a global tmpdir

We allocate temporary things in a few places, and it's
handy to have a pre-created single directory for the
whole install process to use instead of creating
individual tempfiles.

Signed-off-by: Colin Walters <walters@verbum.org>

---

install: Use tmpdir for target fetch verification

We create a transient ostree repo, to do so use the global
install tmpdir.

Signed-off-by: Colin Walters <walters@verbum.org>

---

Initialize a containers-storage: owned by bootc

Initial work for: https://github.com/containers/bootc/issues/721

- Initialize a containers-storage: instance at install time
  (that defaults to empty)
- "Open" it (but do nothing with it) as part of the core CLI
  operations

Further APIs and work will build on top of this.

Signed-off-by: Colin Walters <walters@verbum.org>

---