### PR TITLE
cli: Thread Storage through more places

### DIFF
--- a/lib/src/deploy.rs
+++ b/lib/src/deploy.rs
@@ -268,7 +268,7 @@ pub(crate) async fn pull(
     Ok(Box::new((*import).into()))
 }
 
-pub(crate) async fn cleanup(sysroot: &SysrootLock) -> Result<()> {
+pub(crate) async fn cleanup(sysroot: &Storage) -> Result<()> {
     // We create clones (just atomic reference bumps) here to move to the thread.
     let repo = sysroot.repo();
     let sysroot = sysroot.sysroot.clone();
@@ -329,7 +329,7 @@ pub(crate) fn get_base_commit(repo: &ostree::Repo, commit: &str) -> Result<Optio
 
 #[context("Writing deployment")]
 async fn deploy(
-    sysroot: &SysrootLock,
+    sysroot: &Storage,
     merge_deployment: Option<&Deployment>,
     stateroot: &str,
     image: &ImageState,
@@ -383,7 +383,7 @@ fn origin_from_imageref(imgref: &ImageReference) -> Result<glib::KeyFile> {
 /// Stage (queue deployment of) a fetched container image.
 #[context("Staging")]
 pub(crate) async fn stage(
-    sysroot: &SysrootLock,
+    sysroot: &Storage,
     stateroot: &str,
     image: &ImageState,
     spec: &RequiredHostSpec<'_>,

--- a/lib/src/kargs.rs
+++ b/lib/src/kargs.rs
@@ -10,10 +10,10 @@ use ostree_ext::ostree::Deployment;
 use ostree_ext::prelude::Cast;
 use ostree_ext::prelude::FileEnumeratorExt;
 use ostree_ext::prelude::FileExt;
-use ostree_ext::sysroot::SysrootLock;
 use serde::Deserialize;
 
 use crate::deploy::ImageState;
+use crate::store::Storage;
 
 /// The kargs.d configuration file.
 #[derive(Deserialize)]
@@ -96,7 +96,7 @@ fn get_kargs_from_ostree(
 /// karg, but applies the diff between the bootc karg files in /usr/lib/bootc/kargs.d
 /// between the booted deployment and the new one.
 pub(crate) fn get_kargs(
-    sysroot: &SysrootLock,
+    sysroot: &Storage,
     merge_deployment: &Deployment,
     fetched: &ImageState,
 ) -> Result<Vec<String>> {


### PR DESCRIPTION
This is prep for switching over bound images to use the bootc container storage (and I think is what we want for the bootc-using container-storage).

In the future I think we can actually stop using the magic `Deref` implementation actually too.