### PR TITLE
utils: Add a little CommandRunExt helper trait

### DIFF
--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -46,7 +46,7 @@ use crate::mount::Filesystem;
 use crate::spec::ImageReference;
 use crate::store::Storage;
 use crate::task::Task;
-use crate::utils::sigpolicy_from_opts;
+use crate::utils::{sigpolicy_from_opts, CommandRunExt};
 
 /// The default "stateroot" or "osname"; see https://github.com/ostreedev/ostree/issues/2794
 const STATEROOT_DEFAULT: &str = "default";
@@ -584,10 +584,9 @@ async fn initialize_ostree_root(state: &State, root_setup: &RootSetup) -> Result
         ("sysroot.bootprefix", "true"),
         ("sysroot.readonly", "true"),
     ] {
-        Task::new("Configuring ostree repo", "ostree")
+        Command::new("ostree")
             .args(["config", "--repo", "ostree/repo", "set", k, v])
-            .cwd(rootfs_dir)?
-            .quiet()
+            .cwd_dir(rootfs_dir.try_clone()?)
             .run()?;
     }
     Task::new("Initializing sysroot", "ostree")


### PR DESCRIPTION
When I added the `Task` stuff it wasn't with the idea that we'd use it for *all* subprocess invocations.

I think in some cases we really just do want a `Command` instance without the extra wrappering.

Add an implementation (there are many of variants of this out there in lots of Rust codebases)

This makes sense to use instead of `Task` where we're using `.quiet()` so that we don't print the description, and especially where we don't expect the task to fail usually, so it's OK if the error message is odd.