### PR TITLE
install: Work around bootc-image-builder using /run/osbuild/containers

### DIFF
--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -7,6 +7,7 @@
 // This sub-module is the "basic" installer that handles creating basic block device
 // and filesystem setup.
 pub(crate) mod baseline;
+mod osbuild;
 pub(crate) mod config;
 pub(crate) mod osconfig;
 
@@ -997,36 +998,6 @@ fn ensure_var() -> Result<()> {
     Ok(())
 }
 
-/// Unfortunately today podman requires that /etc be writable for
-/// `/etc/containers/networks`. Detect the situation where it's not
-/// (the main usual cause will be how bootc-image-builder runs us
-///  via a custom bwrap container today) and work around it by
-/// mounting a writable transient overlayfs.
-#[context("Ensuring writable /etc")]
-fn ensure_writable_etc_containers(tempdir: &Dir) -> Result<()> {
-    let etc_containers = Utf8Path::new("/etc/containers");
-    // If there's no /etc/containers, nothing to do
-    if !etc_containers.try_exists()? {
-        return Ok(());
-    }
-    if rustix::fs::access(etc_containers.as_std_path(), rustix::fs::Access::WRITE_OK).is_ok() {
-        return Ok(());
-    }
-    // Create dirs for the overlayfs upper and work in the install-global tmpdir.
-    tempdir.create_dir_all("etc-ovl/upper")?;
-    tempdir.create_dir("etc-ovl/work")?;
-    let opts = format!("lowerdir={etc_containers},workdir=etc-ovl/work,upperdir=etc-ovl/upper");
-    let mut t = Task::new(
-        &format!("Mount transient overlayfs for {etc_containers}"),
-        "mount",
-    )
-    .args(["-t", "overlay", "overlay", "-o", opts.as_str()])
-    .arg(etc_containers);
-    t.cmd.cwd_dir(tempdir.try_clone()?);
-    t.run()?;
-    Ok(())
-}
-
 /// We want to have proper /tmp and /var/tmp without requiring the caller to set them up
 /// in advance by manually specifying them via `podman run -v /tmp:/tmp` etc.
 /// Unfortunately, it's quite complex right now to "gracefully" dynamically reconfigure
@@ -1214,7 +1185,7 @@ async fn prepare_install(
     // creating multiple.
     let tempdir = cap_std_ext::cap_tempfile::TempDir::new(cap_std::ambient_authority())?;
     // And continue to init global state
-    ensure_writable_etc_containers(&tempdir)?;
+    osbuild::adjust_for_bootc_image_builder(&tempdir)?;
 
     if !target_opts.skip_fetch_check {
         verify_target_fetch(&tempdir, &target_imgref).await?;

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -7,8 +7,8 @@
 // This sub-module is the "basic" installer that handles creating basic block device
 // and filesystem setup.
 pub(crate) mod baseline;
-mod osbuild;
 pub(crate) mod config;
+mod osbuild;
 pub(crate) mod osconfig;
 
 use std::io::Write;
@@ -1185,7 +1185,7 @@ async fn prepare_install(
     // creating multiple.
     let tempdir = cap_std_ext::cap_tempfile::TempDir::new(cap_std::ambient_authority())?;
     // And continue to init global state
-    osbuild::adjust_for_bootc_image_builder(&tempdir)?;
+    osbuild::adjust_for_bootc_image_builder(&rootfs, &tempdir)?;
 
     if !target_opts.skip_fetch_check {
         verify_target_fetch(&tempdir, &target_imgref).await?;

--- a/lib/src/install/osbuild.rs
+++ b/lib/src/install/osbuild.rs
@@ -41,10 +41,33 @@ fn adjust_etc_containers(tempdir: &Dir) -> Result<()> {
     Ok(())
 }
 
+/// osbuild mounts the host's /var/lib/containers at /run/osbuild/containers; mount
+/// it back to /var/lib/containers where the default container stack expects to find it.
+fn propagate_run_osbuild_containers(root: &Dir) -> Result<()> {
+    let osbuild_run_containers = Utf8Path::new("run/osbuild/containers");
+    // If we're not apparently running under osbuild, then we no-op.
+    if !root.try_exists(osbuild_run_containers)? {
+        return Ok(());
+    }
+    // If we do seem to have a valid container store though, use that
+    if crate::podman::storage_exists_default(root)? {
+        return Ok(());
+    }
+    let relative_storage = Utf8Path::new(crate::podman::CONTAINER_STORAGE.trim_start_matches('/'));
+    root.create_dir_all(relative_storage)?;
+    Task::new("Creating bind mount for run/osbuild/containers", "mount")
+        .arg("--rbind")
+        .args([osbuild_run_containers, relative_storage])
+        .cwd(root)?
+        .run()?;
+    Ok(())
+}
+
 /// bootc-image-builder today does a few things that we need to
 /// deal with.
 #[context("bootc-image-builder adjustments")]
-pub(crate) fn adjust_for_bootc_image_builder(tempdir: &Dir) -> Result<()> {
+pub(crate) fn adjust_for_bootc_image_builder(root: &Dir, tempdir: &Dir) -> Result<()> {
     adjust_etc_containers(tempdir)?;
+    propagate_run_osbuild_containers(root)?;
     Ok(())
 }

--- a/lib/src/install/osbuild.rs
+++ b/lib/src/install/osbuild.rs
@@ -1,0 +1,50 @@
+//! # Helper APIs for interacting with bootc-image-builder
+//!
+//! See <https://github.com/osbuild/bootc-image-builder>
+//!
+
+use anyhow::Result;
+use camino::Utf8Path;
+use cap_std_ext::{cap_std::fs::Dir, cmdext::CapStdExtCommandExt};
+use fn_error_context::context;
+
+use crate::task::Task;
+
+/// Handle /etc/containers readonly mount.
+///
+/// Ufortunately today podman requires that /etc be writable for
+/// `/etc/containers/networks`. bib today creates this as a readonly mount:
+/// https://github.com/osbuild/osbuild/blob/4edbe227d41c767441b9bf4390398afc6dc8f901/osbuild/buildroot.py#L243
+///
+/// Work around that by adding a transient, writable overlayfs.
+fn adjust_etc_containers(tempdir: &Dir) -> Result<()> {
+    let etc_containers = Utf8Path::new("/etc/containers");
+    // If there's no /etc/containers, nothing to do
+    if !etc_containers.try_exists()? {
+        return Ok(());
+    }
+    if rustix::fs::access(etc_containers.as_std_path(), rustix::fs::Access::WRITE_OK).is_ok() {
+        return Ok(());
+    }
+    // Create dirs for the overlayfs upper and work in the install-global tmpdir.
+    tempdir.create_dir_all("etc-ovl/upper")?;
+    tempdir.create_dir("etc-ovl/work")?;
+    let opts = format!("lowerdir={etc_containers},workdir=etc-ovl/work,upperdir=etc-ovl/upper");
+    let mut t = Task::new(
+        &format!("Mount transient overlayfs for {etc_containers}"),
+        "mount",
+    )
+    .args(["-t", "overlay", "overlay", "-o", opts.as_str()])
+    .arg(etc_containers);
+    t.cmd.cwd_dir(tempdir.try_clone()?);
+    t.run()?;
+    Ok(())
+}
+
+/// bootc-image-builder today does a few things that we need to
+/// deal with.
+#[context("bootc-image-builder adjustments")]
+pub(crate) fn adjust_for_bootc_image_builder(tempdir: &Dir) -> Result<()> {
+    adjust_etc_containers(tempdir)?;
+    Ok(())
+}


### PR DESCRIPTION
install: Factor out an osbuild module

Unfortunately the interactions/workarounds here are going to grow, so make
a module to encapsulate them.

Signed-off-by: Colin Walters <walters@verbum.org>

---

install: Work around bootc-image-builder using /run/osbuild/containers

xref: https://github.com/osbuild/bootc-image-builder/issues/560

Basically osbuild/bib puts the host `/var/lib/containers` at
`/run/osbuild/containers`. If we detect this situation, bind
mount it to `/var/lib/containers` so that the container
stack we invoke at install time can find logically bound
images.

Closes: https://github.com/containers/bootc/issues/715

Signed-off-by: Colin Walters <walters@verbum.org>

---