### PR TITLE
Release 0.1.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "bootc-lib"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anstream",
  "anstyle",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT OR Apache-2.0"
 name = "bootc-lib"
 readme = "README.md"
 repository = "https://github.com/containers/bootc"
-version = "0.1.15"
+version = "0.1.16"
 # For now don't bump this above what is currently shipped in RHEL9;
 # also keep in sync with the version in cli.
 rust-version = "1.75.0"


### PR DESCRIPTION
The major change here is we dropped our dependency on `gdisk` in favor of sfdisk from util-linux, which is more widely available and better maintained.