### PR TITLE
install: Drop SELinux-disabled warning

### DIFF
--- a/lib/src/lsm.rs
+++ b/lib/src/lsm.rs
@@ -99,6 +99,7 @@ pub(crate) fn selinux_ensure_install() -> Result<bool> {
 /// gain the `mac_admin` permission (install_t).
 #[cfg(feature = "install")]
 #[must_use]
+#[derive(Debug)]
 pub(crate) struct SetEnforceGuard(Option<()>);
 
 #[cfg(feature = "install")]


### PR DESCRIPTION
We have e2e tests for this today. On a related topic, unfortunately the way bootc-image-builder sets up the container it runs bootc in it doesn't mount selinuxfs, so we see SELinux as disabled when it's not.

We should fix that, but it also avoids user confusion to drop the warning here.

While we're here, change things so we more consistently log the state computed.

Closes: https://github.com/containers/bootc/issues/419