### PR TITLE
install-to-disk: Check for mounts before install

### DIFF
--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -1802,6 +1802,7 @@ fn test_gather_root_args() {
         maj_min: "252:4".into(),
         options: "rw".into(),
         uuid: Some("965eb3c7-5a3f-470d-aaa2-1bcf04334bc6".into()),
+        children: None,
     };
     let r = find_root_args_to_inherit(&[], &inspect).unwrap();
     assert_eq!(r.mount_spec, "UUID=965eb3c7-5a3f-470d-aaa2-1bcf04334bc6");

--- a/lib/src/mount.rs
+++ b/lib/src/mount.rs
@@ -12,6 +12,7 @@ use crate::task::Task;
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
+#[allow(dead_code)]
 pub(crate) struct Filesystem {
     // Note if you add an entry to this list, you need to change the --output invocation below too
     pub(crate) source: String,
@@ -21,6 +22,7 @@ pub(crate) struct Filesystem {
     pub(crate) fstype: String,
     pub(crate) options: String,
     pub(crate) uuid: Option<String>,
+    pub(crate) children: Option<Vec<Filesystem>>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -28,7 +30,7 @@ pub(crate) struct Findmnt {
     pub(crate) filesystems: Vec<Filesystem>,
 }
 
-fn run_findmnt(args: &[&str], path: &str) -> Result<Filesystem> {
+fn run_findmnt(args: &[&str], path: &str) -> Result<Findmnt> {
     let o: Findmnt = Command::new("findmnt")
         .args([
             "-J",
@@ -40,6 +42,12 @@ fn run_findmnt(args: &[&str], path: &str) -> Result<Filesystem> {
         .arg(path)
         .log_debug()
         .run_and_parse_json()?;
+    Ok(o)
+}
+
+// Retrieve a mounted filesystem from a device given a matching path
+fn findmnt_filesystem(args: &[&str], path: &str) -> Result<Filesystem> {
+    let o = run_findmnt(args, path)?;
     o.filesystems
         .into_iter()
         .next()
@@ -50,13 +58,40 @@ fn run_findmnt(args: &[&str], path: &str) -> Result<Filesystem> {
 /// Inspect a target which must be a mountpoint root - it is an error
 /// if the target is not the mount root.
 pub(crate) fn inspect_filesystem(path: &Utf8Path) -> Result<Filesystem> {
-    run_findmnt(&["--mountpoint"], path.as_str())
+    findmnt_filesystem(&["--mountpoint"], path.as_str())
 }
 
 #[context("Inspecting filesystem by UUID {uuid}")]
 /// Inspect a filesystem by partition UUID
 pub(crate) fn inspect_filesystem_by_uuid(uuid: &str) -> Result<Filesystem> {
-    run_findmnt(&["--source"], &(format!("UUID={uuid}")))
+    findmnt_filesystem(&["--source"], &(format!("UUID={uuid}")))
+}
+
+// Check if a specified device contains an already mounted filesystem
+// in the root mount namespace
+pub(crate) fn is_mounted_in_pid1_mountns(path: &str) -> Result<bool> {
+    let o = run_findmnt(&["-N"], "1")?;
+
+    let mounted = o.filesystems.iter().any(|fs| is_source_mounted(path, fs));
+
+    Ok(mounted)
+}
+
+// Recursively check a given filesystem to see if it contains an already mounted source
+pub(crate) fn is_source_mounted(path: &str, mounted_fs: &Filesystem) -> bool {
+    if mounted_fs.source.contains(path) {
+        return true;
+    }
+
+    if let Some(ref children) = mounted_fs.children {
+        for child in children {
+            if is_source_mounted(path, child) {
+                return true;
+            }
+        }
+    }
+
+    false
 }
 
 /// Mount a device to the target path.


### PR DESCRIPTION
Works to improve `bootc install to-disk` flow by checking for mounts on the device to be installed to. If mounts are present then install will abort. 

Resolves #720 