### PR TITLE
store: Get timestamp from config or annotation

### DIFF
--- a/lib/src/store/ostree_container.rs
+++ b/lib/src/store/ostree_container.rs
@@ -51,6 +51,7 @@ fn create_imagestatus(
             l.get(oci_spec::image::ANNOTATION_CREATED)
                 .map(|s| s.as_str())
         })
+        .or_else(|| config.created().as_deref())
         .and_then(try_deserialize_timestamp);
 
     let version = ostree_container::version_for_config(config).map(ToOwned::to_owned);

--- a/tests/booted/readonly/001-test-status.nu
+++ b/tests/booted/readonly/001-test-status.nu
@@ -9,4 +9,5 @@ let st = bootc status --json --format-version=0 | from json
 assert equal $st.apiVersion org.containers.bootc/v1
 let st = bootc status --format=yaml | from yaml
 assert equal $st.apiVersion org.containers.bootc/v1
+assert ($st.status.booted.image.timestamp != null)
 tap ok


### PR DESCRIPTION
Sadly this code got forked from ostree-rs-ext, where we were doing things correctly. Add the fallback
to the config.