### PR TITLE
test: add ostree-rs-ext version-skew test

### DIFF
--- a/tests/e2e/playbooks/check-system.yaml
+++ b/tests/e2e/playbooks/check-system.yaml
@@ -45,7 +45,25 @@
 
     - name: check rpm-ostree status
       command: rpm-ostree status
+      register: result_rpm_ostree_status
       ignore_errors: true
+
+    # issue https://github.com/containers/bootc/issues/800
+    # ostree-rs-ext version-skew test (bumped in rpm-ostree and in bootc)
+    - name: check rpm-ostree output
+      block:
+        - assert:
+            that:
+              - "'error' not in result_rpm_ostree_status.stdout"
+            fail_msg: "rpm-ostree status failed"
+            success_msg: "rpm-ostree status succeeded"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
 
     - name: check bootc status
       command: bootc status


### PR DESCRIPTION
Test comes from issue https://github.com/containers/bootc/issues/800.

Both rpm-ostree and bootc bump ostree-rs-ext. This test is to avoid version-skew issue.

Test already catch this issue in our CI in rpm-ostree status test (https://artifacts.dev.testing-farm.io/00c7ce6c-d233-448f-891f-4fb484d4d710/) , but I did not failed this test. Let's enabled the error checking there.

```
TASK [check rpm-ostree status] *************************************************
changed: [guest] => changed=true 
  cmd:
  - rpm-ostree
  - status
  delta: '0:00:00.140106'
  end: '2024-09-19 20:38:24.470069'
  msg: ''
  rc: 0
  start: '2024-09-19 20:38:24.329963'
  stderr: ''
  stderr_lines: <omitted>
  stdout: |-
    State: idle
    Deployments:
    ● (error fetching image metadata)
                    Timestamp: 2024-09-19T20:32:03Z
  stdout_lines: <omitted>
```