### PR TITLE
lbi: Add --remove-signatures to install time lbi copy

### DIFF
--- a/lib/src/imgstorage.rs
+++ b/lib/src/imgstorage.rs
@@ -296,7 +296,7 @@ impl Storage {
         let storage_dest = &format!(
             "containers-storage:[overlay@{STORAGE_ALIAS_DIR}+/proc/self/fd/{STORAGE_RUN_FD}]"
         );
-        cmd.args(["image", "push", image])
+        cmd.args(["image", "push", "--remove-signatures", image])
             .arg(format!("{storage_dest}{image}"));
         let mut cmd = AsyncCommand::from(cmd);
         cmd.run().await?;

--- a/tests/booted/test-logically-bound-install.nu
+++ b/tests/booted/test-logically-bound-install.nu
@@ -6,5 +6,6 @@ print "IMAGES:"
 podman --storage-opt=additionalimagestore=/usr/lib/bootc/storage images # for debugging
 assert ($images | any {|item| $item.column1 == "quay.io/curl/curl"})
 assert ($images | any {|item| $item.column1 == "quay.io/curl/curl-base"})
+assert ($images | any {|item| $item.column1 == "registry.redhat.io/ubi9/podman"}) # this image is signed
 
 tap ok

--- a/tests/containerfiles/lbi/Containerfile
+++ b/tests/containerfiles/lbi/Containerfile
@@ -3,4 +3,5 @@ FROM localhost/bootc
 COPY ./usr/. /usr
 
 RUN ln -s /usr/share/containers/systemd/curl.container /usr/lib/bootc/bound-images.d/curl.container && \
-    ln -s /usr/share/containers/systemd/curl-base.image /usr/lib/bootc/bound-images.d/curl-base.image
+    ln -s /usr/share/containers/systemd/curl-base.image /usr/lib/bootc/bound-images.d/curl-base.image && \
+    ln -s /usr/share/containers/systemd/podman.image /usr/lib/bootc/bound-images.d/podman.image

--- a/tests/containerfiles/lbi/usr/share/containers/systemd/podman.image
+++ b/tests/containerfiles/lbi/usr/share/containers/systemd/podman.image
@@ -1,0 +1,2 @@
+[Image]
+Image=registry.redhat.io/ubi9/podman:latest

--- a/xtask/src/xtask.rs
+++ b/xtask/src/xtask.rs
@@ -11,7 +11,11 @@ use fn_error_context::context;
 use xshell::{cmd, Shell};
 
 const NAME: &str = "bootc";
-const TEST_IMAGES: &[&str] = &["quay.io/curl/curl-base:latest", "quay.io/curl/curl:latest"];
+const TEST_IMAGES: &[&str] = &[
+    "quay.io/curl/curl-base:latest",
+    "quay.io/curl/curl:latest",
+    "registry.redhat.io/ubi9/podman:latest",
+];
 
 fn main() {
     if let Err(e) = try_main() {


### PR DESCRIPTION
We are unable to copy a signed image from c/storage -> c/storage while preserving the signature. See
https://github.com/containers/image/issues/2599

fixes #812