### PR TITLE
docs: install: Add /dev volume mounts for loopback example

### DIFF
--- a/docs/src/bootc-install.md
+++ b/docs/src/bootc-install.md
@@ -166,7 +166,7 @@ via e.g.:
 
 ```bash
 truncate -s 10G myimage.raw
-podman run --rm --privileged --pid=host --security-opt label=type:unconfined_t  -v /var/lib/containers:/var/lib/containers -v .:/output <yourimage> bootc install to-disk --generic-image --via-loopback /output/myimage.raw
+podman run --rm --privileged --pid=host --security-opt label=type:unconfined_t -v /dev:/dev -v /var/lib/containers:/var/lib/containers -v .:/output <yourimage> bootc install to-disk --generic-image --via-loopback /output/myimage.raw
 ```
 
 Notice that we use `--generic-image` for this use case.


### PR DESCRIPTION
Without this, we error out with:

ERROR Installing to disk: Loopback mounts (--via-loopback) require host devices (-v /dev:/dev)

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
