### PR TITLE
Drop gvariant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,6 @@ dependencies = [
  "clap",
  "clap_mangen",
  "fn-error-context",
- "gvariant",
  "hex",
  "indicatif",
  "indoc",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -26,7 +26,6 @@ clap_mangen = { version = "0.2.20", optional = true }
 cap-std-ext = { workspace = true, features = ["fs_utf8"] }
 hex = "^0.4.3"
 fn-error-context = { workspace = true }
-gvariant = "0.5.0"
 indicatif = "0.17.8"
 libc = { workspace = true }
 liboverdrop = "0.1.0"

--- a/lib/src/lsm.rs
+++ b/lib/src/lsm.rs
@@ -419,3 +419,19 @@ where
         f(w)
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gio::glib::Variant;
+
+    #[test]
+    fn test_selinux_xattr() {
+        let notfound: &[&[(&[u8], &[u8])]] = &[&[], &[(b"foo", b"bar")]];
+        for case in notfound {
+            assert!(!xattrs_have_selinux(&Variant::from(case)));
+        }
+        let found: &[(&[u8], &[u8])] = &[(b"foo", b"bar"), (SELINUX_XATTR, b"foo_t")];
+        assert!(xattrs_have_selinux(&Variant::from(found)));
+    }
+}


### PR DESCRIPTION
It isn't an actively maintained crate and our usage is tiny
and not performance sensitive enough to warrant the zero-copy
it entails.

Just motivated by doing a pass over our dependencies.

Signed-off-by: Colin Walters <walters@verbum.org>