### PR TITLE
lib: Bump version to 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "bootc-lib"
-version = "0.1.16"
+version = "1.1.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,7 +19,7 @@ platforms = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "powerpc64
 
 [dependencies]
 anyhow = { workspace = true }
-bootc-lib = { version = "0.1", path = "../lib" }
+bootc-lib = { version = "1.0", path = "../lib" }
 clap = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 log = "0.4.21"

--- a/docs/src/man/bootc-container-lint.md
+++ b/docs/src/man/bootc-container-lint.md
@@ -23,4 +23,4 @@ part of a build process; it will error if any problems are detected.
 
 # VERSION
 
-v0.1.16
+v1.1.0

--- a/docs/src/man/bootc-container.md
+++ b/docs/src/man/bootc-container.md
@@ -30,4 +30,4 @@ bootc-container-help(8)
 
 # VERSION
 
-v0.1.16
+v1.1.0

--- a/docs/src/man/bootc-edit.md
+++ b/docs/src/man/bootc-edit.md
@@ -36,4 +36,4 @@ Only changes to the \`spec\` section are honored.
 
 # VERSION
 
-v0.1.16
+v1.1.0

--- a/docs/src/man/bootc-install-print-configuration.md
+++ b/docs/src/man/bootc-install-print-configuration.md
@@ -27,4 +27,4 @@ string-valued filesystem name suitable for passing to \`mkfs.\$type\`.
 
 # VERSION
 
-v0.1.16
+v1.1.0

--- a/docs/src/man/bootc-install-to-disk.md
+++ b/docs/src/man/bootc-install-to-disk.md
@@ -149,4 +149,4 @@ firmware will be skipped
 
 # VERSION
 
-v0.1.16
+v1.1.0

--- a/docs/src/man/bootc-install-to-existing-root.md
+++ b/docs/src/man/bootc-install-to-existing-root.md
@@ -134,4 +134,4 @@ firmware will be skipped
 
 # VERSION
 
-v0.1.16
+v1.1.0

--- a/docs/src/man/bootc-install-to-filesystem.md
+++ b/docs/src/man/bootc-install-to-filesystem.md
@@ -161,4 +161,4 @@ mounting. To override this, use \`\--root-mount-spec\`.
 
 # VERSION
 
-v0.1.16
+v1.1.0

--- a/docs/src/man/bootc-install.md
+++ b/docs/src/man/bootc-install.md
@@ -10,7 +10,7 @@ bootc-install - Install the running container to a target
 
 Install the running container to a target.
 
-## Understanding installations
+\## Understanding installations
 
 OCI containers are effectively layers of tarballs with JSON for
 metadata; they cannot be booted directly. The \`bootc install\` flow is
@@ -61,4 +61,4 @@ bootc-install-help(8)
 
 # VERSION
 
-v0.1.16
+v1.1.0

--- a/docs/src/man/bootc-rollback.md
+++ b/docs/src/man/bootc-rollback.md
@@ -34,4 +34,4 @@ rollback invocation.
 
 # VERSION
 
-v0.1.16
+v1.1.0

--- a/docs/src/man/bootc-status.md
+++ b/docs/src/man/bootc-status.md
@@ -16,13 +16,13 @@ bootc system state. If standard output is not a terminal, output a
 YAML-formatted object using a schema intended to match a Kubernetes
 resource that describes the state of the booted system.
 
-## Parsing output via programs
+\## Parsing output via programs
 
 Either the default YAML format or \`\--format=json\` can be used. Do not
 attempt to explicitly parse the output of \`\--format=humanreadable\` as
 it will very likely change over time.
 
-## Programmatically detecting whether the system is deployed via bootc
+\## Programmatically detecting whether the system is deployed via bootc
 
 Invoke e.g. \`bootc status \--json\`, and check if \`status.booted\` is
 not \`null\`.
@@ -59,4 +59,4 @@ not \`null\`.
 
 # VERSION
 
-v0.1.16
+v1.1.0

--- a/docs/src/man/bootc-switch.md
+++ b/docs/src/man/bootc-switch.md
@@ -15,7 +15,7 @@ Target a new container image reference to boot.
 This is almost exactly the same operation as \`upgrade\`, but
 additionally changes the container image reference instead.
 
-## Usage
+\## Usage
 
 A common pattern is to have a management agent control operating system
 updates via container image tags; for example,
@@ -69,4 +69,4 @@ includes a default policy which requires signatures.
 
 # VERSION
 
-v0.1.16
+v1.1.0

--- a/docs/src/man/bootc-upgrade.md
+++ b/docs/src/man/bootc-upgrade.md
@@ -52,4 +52,4 @@ userspace-only restart.
 
 # VERSION
 
-v0.1.16
+v1.1.0

--- a/docs/src/man/bootc-usr-overlay.md
+++ b/docs/src/man/bootc-usr-overlay.md
@@ -12,20 +12,20 @@ will be discarded on reboot
 Adds a transient writable overlayfs on \`/usr\` that will be discarded
 on reboot.
 
-## Use cases
+\## Use cases
 
 A common pattern is wanting to use tracing/debugging tools, such as
 \`strace\` that may not be in the base image. A system package manager
 such as \`apt\` or \`dnf\` can apply changes into this transient overlay
 that will be discarded on reboot.
 
-## /etc and /var
+\## /etc and /var
 
 However, this command has no effect on \`/etc\` and \`/var\` - changes
 written there will persist. It is common for package installations to
 modify these directories.
 
-## Unmounting
+\## Unmounting
 
 Almost always, a system process will hold a reference to the open mount
 point. You can however invoke \`umount -l /usr\` to perform a \"lazy
@@ -39,4 +39,4 @@ unmount\".
 
 # VERSION
 
-v0.1.16
+v1.1.0

--- a/docs/src/man/bootc.md
+++ b/docs/src/man/bootc.md
@@ -72,4 +72,4 @@ bootc-help(8)
 
 # VERSION
 
-v0.1.16
+v1.1.0

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT OR Apache-2.0"
 name = "bootc-lib"
 readme = "README.md"
 repository = "https://github.com/containers/bootc"
-version = "0.1.16"
+version = "1.1.0"
 # For now don't bump this above what is currently shipped in RHEL9;
 # also keep in sync with the version in cli.
 rust-version = "1.75.0"


### PR DESCRIPTION
We'll support all APIs and features we have now for the forseeable future.

Why not 1.0.0? Just to avoid making this version feel too "special".