### PR TITLE
lbi: Switch to unauthenticated ubi9 for lbi test

### DIFF
--- a/tests/booted/test-logically-bound-install.nu
+++ b/tests/booted/test-logically-bound-install.nu
@@ -6,6 +6,6 @@ print "IMAGES:"
 podman --storage-opt=additionalimagestore=/usr/lib/bootc/storage images # for debugging
 assert ($images | any {|item| $item.column1 == "quay.io/curl/curl"})
 assert ($images | any {|item| $item.column1 == "quay.io/curl/curl-base"})
-assert ($images | any {|item| $item.column1 == "registry.redhat.io/ubi9/podman"}) # this image is signed
+assert ($images | any {|item| $item.column1 == "registry.access.redhat.com/ubi9/podman:latest"}) # this image is signed
 
 tap ok

--- a/tests/containerfiles/lbi/usr/share/containers/systemd/podman.image
+++ b/tests/containerfiles/lbi/usr/share/containers/systemd/podman.image
@@ -1,2 +1,2 @@
 [Image]
-Image=registry.redhat.io/ubi9/podman:latest
+Image=registry.access.redhat.com/ubi9/podman:latest

--- a/xtask/src/xtask.rs
+++ b/xtask/src/xtask.rs
@@ -14,7 +14,7 @@ const NAME: &str = "bootc";
 const TEST_IMAGES: &[&str] = &[
     "quay.io/curl/curl-base:latest",
     "quay.io/curl/curl:latest",
-    "registry.redhat.io/ubi9/podman:latest",
+    "registry.access.redhat.com/ubi9/podman:latest",
 ];
 
 fn main() {


### PR DESCRIPTION
This way we don't need to add any credentials to github.