### PR TITLE
docs: Fix link

### DIFF
--- a/docs/src/filesystem-sysroot.md
+++ b/docs/src/filesystem-sysroot.md
@@ -29,7 +29,7 @@ operate on the physical root.
 
 ### bootc-owned container storage
 
-For [logically bound images](experimental-logically-bound-images.md),
+For [logically bound images](logically-bound-images.md),
 bootc maintains a dedicated [containers/storage](https://github.com/containers/storage)
 instance using the `overlay` backend (the same type of thing that backs `/var/lib/containers`).
 


### PR DESCRIPTION
We were failing to publish the docs because of this.