### PR TITLE
ci: Update Packit target to Fedora 41 from Fedora 40

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -38,7 +38,7 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
-      # Primary targets are c9s and fedora:40 right now, which build
+      # Primary targets are c9s, c10s and fedora:41 right now, which build
       # for all architectures
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64
@@ -48,10 +48,10 @@ jobs:
       - centos-stream-10-aarch64
       - centos-stream-10-ppc64le
       - centos-stream-10-s390x
-      - fedora-40-x86_64
-      - fedora-40-aarch64
-      - fedora-40-ppc64le
-      - fedora-40-s390x
+      - fedora-41-x86_64
+      - fedora-41-aarch64
+      - fedora-41-ppc64le
+      - fedora-41-s390x
       # Sanity check on secondary targets, fewer architectures just
       # because the chance that we break e.g. ppc64le *just* on
       # rawhide is basically nil.
@@ -63,8 +63,8 @@ jobs:
   - job: tests
     trigger: pull_request
     targets:
-      - fedora-40-x86_64
-      - fedora-40-aarch64
+      - fedora-41-x86_64
+      - fedora-41-aarch64
     tmt_plan: /integration-build
     skip_build: true
     identifier: integration-test
@@ -75,9 +75,8 @@ jobs:
     trigger: pull_request
     targets:
       - centos-stream-9-x86_64
-      - centos-stream-9-aarch64
       - centos-stream-10-aarch64
-      - fedora-40-x86_64
+      - fedora-41-x86_64
     tmt_plan: /to-existing-root
     identifier: e2e-test-to-existing-root
 
@@ -85,8 +84,7 @@ jobs:
     trigger: pull_request
     targets:
       - centos-stream-9-aarch64
-      - centos-stream-10-x86_64
       - centos-stream-10-aarch64
-      - fedora-40-aarch64
+      - fedora-41-aarch64
     tmt_plan: /to-disk
     identifier: e2e-test-to-disk

--- a/tests/e2e/bootc-install.sh
+++ b/tests/e2e/bootc-install.sh
@@ -175,10 +175,10 @@ cat "$INSTALL_CONTAINERFILE"
 
 # Build test bootc image and push to local registry
 greenprint "Build $TEST_OS installation container image"
-sudo podman build --tls-verify=false --retry=5 --retry-delay=10 -t "${TEST_IMAGE_NAME}:${QUAY_REPO_TAG}" -f "$INSTALL_CONTAINERFILE" "$TEMPDIR"
+sudo podman build --tls-verify=false -t "${TEST_IMAGE_NAME}:${QUAY_REPO_TAG}" -f "$INSTALL_CONTAINERFILE" "$TEMPDIR"
 
 greenprint "Push $TEST_OS installation container image"
-retry sudo podman push --tls-verify=false --quiet "${TEST_IMAGE_NAME}:${QUAY_REPO_TAG}" "$TEST_IMAGE_URL"
+sudo podman push --tls-verify=false --quiet "${TEST_IMAGE_NAME}:${QUAY_REPO_TAG}" "$TEST_IMAGE_URL"
 
 # Prepare Ansible inventory file and ansible.cfg
 greenprint "Prepare inventory file"
@@ -296,14 +296,14 @@ REALEOF
 
 # Build upgrade container image and push to locay registry
 greenprint "Build $TEST_OS upgrade container image"
-sudo podman build --tls-verify=false --retry=5 --retry-delay=10 -t "${TEST_IMAGE_NAME}:${QUAY_REPO_TAG}" -f "$UPGRADE_CONTAINERFILE" .
+sudo podman build --tls-verify=false -t "${TEST_IMAGE_NAME}:${QUAY_REPO_TAG}" -f "$UPGRADE_CONTAINERFILE" .
 
 greenprint "Push $TEST_OS upgrade container image"
-retry sudo podman push --tls-verify=false --quiet "${TEST_IMAGE_NAME}:${QUAY_REPO_TAG}" "$TEST_IMAGE_URL"
+sudo podman push --tls-verify=false --quiet "${TEST_IMAGE_NAME}:${QUAY_REPO_TAG}" "$TEST_IMAGE_URL"
 
 # Copy upgrade image to local folder for bootc switch test
 if [[ "$AIR_GAPPED_DIR" != "" ]]; then
-    retry skopeo copy docker://"$TEST_IMAGE_URL" dir://"$AIR_GAPPED_DIR"
+    skopeo copy docker://"$TEST_IMAGE_URL" dir://"$AIR_GAPPED_DIR"
     BOOTC_IMAGE="/mnt"
 else
     BOOTC_IMAGE="$TEST_IMAGE_URL"

--- a/tests/e2e/shared_lib.sh
+++ b/tests/e2e/shared_lib.sh
@@ -35,17 +35,6 @@ function redprint {
     echo -e "\033[1;31m[$(date -Isecond)] ${1}\033[0m"
 }
 
-# Retry container image pull and push
-function retry {
-    n=0
-    until [ "$n" -ge 3 ]
-    do
-       "$@" && break
-       n=$((n+1))
-       sleep 10
-    done
-}
-
 function deploy_libvirt_network {
     greenprint "Start firewalld"
     sudo systemctl enable --now firewalld


### PR DESCRIPTION
Fedora 41 released already, it's time to drop Fedora 40 test and run Fedora 41 test instead