### PR TITLE
install: Add support for pulling LBIs during install

### DIFF
--- a/lib/src/boundimage.rs
+++ b/lib/src/boundimage.rs
@@ -108,6 +108,7 @@ pub(crate) fn query_bound_images(root: &Dir) -> Result<Vec<BoundImage>> {
 
 #[cfg(feature = "install")]
 impl ResolvedBoundImage {
+    #[context("resolving bound image {}", src.image)]
     pub(crate) async fn from_image(src: &BoundImage) -> Result<Self> {
         let proxy = containers_image_proxy::ImageProxy::new().await?;
         let img = proxy
@@ -148,7 +149,10 @@ fn parse_container_file(file_contents: &tini::Ini) -> Result<BoundImage> {
 }
 
 #[context("Pulling bound images")]
-pub(crate) async fn pull_images(sysroot: &Storage, bound_images: Vec<BoundImage>) -> Result<()> {
+pub(crate) async fn pull_images(
+    sysroot: &Storage,
+    bound_images: Vec<crate::boundimage::BoundImage>,
+) -> Result<()> {
     tracing::debug!("Pulling bound images: {}", bound_images.len());
     // Yes, the usage of NonZeroUsize here is...maybe odd looking, but I find
     // it an elegant way to divide (empty vector, non empty vector) since

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -1039,6 +1039,11 @@ fn test_parse_install_args() {
     };
     assert!(o.target_opts.target_no_signature_verification);
     assert_eq!(o.filesystem_opts.root_path.as_str(), "/target");
+    // Ensure we default to old bound images behavior
+    assert_eq!(
+        o.config_opts.bound_images,
+        crate::install::BoundImagesOpt::Stored
+    );
 }
 
 #[test]


### PR DESCRIPTION
Partially solves #846

This adds a new `--bound-images` option to `bootc install` which will allow the user to choose how they want to handle the retrieval of LBIs into the target's container storage.

The existing behavior, which will stay the default, is `--bound-images stored` which will resolve the LBIs and verify they exist in the source's container storage before copying them into the target's container storage.

The new behavior is `--bound-images pull` which will skip the resolution step and directly pull the LBIs into the target's container storage.

The older `--skip-bound-images` option (previously hidden) is now removed and replaced with the new (but still hidden) `--bound-images skip` option.