### PR TITLE
install: improve error message when existing partitions are detected

### DIFF
--- a/lib/src/install/baseline.rs
+++ b/lib/src/install/baseline.rs
@@ -180,7 +180,7 @@ pub(crate) fn install_create_rootfs(
         crate::blockdev::wipefs(dev)?;
     } else if device.has_children() {
         anyhow::bail!(
-            "Detected existing partitions on {}; use e.g. `wipefs` if you intend to overwrite",
+            "Detected existing partitions on {}; use e.g. `wipefs` or --wipe if you intend to overwrite",
             opts.device
         );
     }


### PR DESCRIPTION
When existing partitions are detected, suggest using bootc flag `--wipe` to wipe them, and not just the `wipefs` command.