### PR TITLE
List logically bound images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_mangen",
+ "comfy-table",
  "fn-error-context",
  "hex",
  "indicatif",
@@ -410,6 +411,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "comfy-table"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24f165e7b643266ea80cb858aed492ad9280e3e05ce24d4a99d7d7b889b6a4d9"
+dependencies = [
+ "crossterm",
+ "strum",
+ "strum_macros",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "console"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,6 +476,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.6.0",
+ "crossterm_winapi",
+ "parking_lot",
+ "rustix",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1131,6 +1166,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,6 +1476,29 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "pin-project"
@@ -1754,6 +1822,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.87",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -46,6 +46,7 @@ toml = "0.8.12"
 xshell = { version = "0.2.6", optional = true }
 uuid = { version = "1.8.0", features = ["v4"] }
 tini = "1.3.0"
+comfy-table = "7.1.1"
 
 [dev-dependencies]
 indoc = { workspace = true }

--- a/tests/booted/test-logically-bound-install.nu
+++ b/tests/booted/test-logically-bound-install.nu
@@ -1,11 +1,41 @@
 use std assert
 use tap.nu
 
-let images = podman --storage-opt=additionalimagestore=/usr/lib/bootc/storage images --format {{.Repository}} | from csv --noheaders
-print "IMAGES:"
-podman --storage-opt=additionalimagestore=/usr/lib/bootc/storage images # for debugging
-assert ($images | any {|item| $item.column1 == "quay.io/curl/curl"})
-assert ($images | any {|item| $item.column1 == "quay.io/curl/curl-base"})
-assert ($images | any {|item| $item.column1 == "registry.access.redhat.com/ubi9/podman"}) # this image is signed
+# This list reflects the LBIs specified in bootc/tests/containerfiles/lbi/usr/share/containers/systemd
+let expected_images = [
+    "quay.io/curl/curl:latest",
+    "quay.io/curl/curl-base:latest",
+    "registry.access.redhat.com/ubi9/podman:latest" # this image is signed
+]
+
+def validate_images [images: table] {
+    print $"Validating images ($images)"
+    for expected in $expected_images {
+        assert ($images | any {|item| $item.image == $expected})
+    }
+}
+
+# This test checks that bootc actually populated the bootc storage with the LBI images
+def test_logically_bound_images_in_storage [] {
+    # Use podman to list the images in the bootc storage
+    let images = podman --storage-opt=additionalimagestore=/usr/lib/bootc/storage images --format {{.Repository}}:{{.Tag}} | from csv --noheaders | rename --column { column1: image }
+
+    # Debug print
+    print "IMAGES:"
+    podman --storage-opt=additionalimagestore=/usr/lib/bootc/storage images
+
+    validate_images $images
+}
+
+# This test makes sure that bootc itself knows how to list the LBI images in the bootc storage
+def test_bootc_image_list [] {
+    # Use bootc to list the images in the bootc storage
+    let images = bootc image list --type logical --format json | from json
+
+    validate_images $images
+}
+
+test_logically_bound_images_in_storage
+test_bootc_image_list
 
 tap ok


### PR DESCRIPTION
Solves the second part of https://github.com/containers/bootc/issues/846

The (hidden) image list command now has a `--type` flag to allow users to list only logical images, only host images, or all images.

Also the command has been adjusted so that it can run even when not booted off of a bootc system. In that case, it will only list logical images. If a user tries to list host images without a booted system, an error will be thrown.

The command also has a `--format` flag to allow users to choose between a human-readable table format and a JSON format.