### PR TITLE
lib/blockdev: Handle devicemapper path

### DIFF
--- a/lib/src/blockdev.rs
+++ b/lib/src/blockdev.rs
@@ -37,13 +37,14 @@ pub(crate) struct Device {
     // Filesystem-related properties
     pub(crate) label: Option<String>,
     pub(crate) fstype: Option<String>,
+    pub(crate) path: Option<String>,
 }
 
 impl Device {
     #[allow(dead_code)]
     // RHEL8's lsblk doesn't have PATH, so we do it
     pub(crate) fn path(&self) -> String {
-        format!("/dev/{}", &self.name)
+        self.path.clone().unwrap_or(format!("/dev/{}", &self.name))
     }
 
     pub(crate) fn has_children(&self) -> bool {


### PR DESCRIPTION
Bootc install to-disk command fails to recognize correct path of device-mapper
devices. As a result bootc install command on device-mapper fails with

Wiping /dev/mpathe1
Wiping device /dev/mpathe1
wipefs: error: /dev/mpathe1: probing initialization failed: No such file or directory ERROR Installing to disk: Creating rootfs: Failed to wipe /dev/mpathe1: Task Wiping device /dev/mpathe1 failed: ExitStatus(unix_wait_status(256))

Make sure the device name is captured correctly.
Results with the fix:

Wiping /dev/mapper/mpathe1
Wiping device /dev/mapper/mpathe1
Wiping /dev/mapper/mpathe2
Wiping device /dev/mapper/mpathe2
Wiping /dev/mapper/mpathe
Wiping device /dev/mapper/mpathe

Thanks to Dharaneeshwaran for debugging the problem.