### PR TITLE
cli: Wrap ostree-ext via `bootc internals`

### DIFF
--- a/tests/booted/readonly/11-ostree-ext-cli.nu
+++ b/tests/booted/readonly/11-ostree-ext-cli.nu
@@ -1,0 +1,13 @@
+# Verify our wrapped "bootc internals ostree-container" calling into
+# the legacy ostree-ext CLI.
+use std assert
+use tap.nu
+
+tap begin "verify bootc wrapping ostree-ext"
+
+# Parse the status and get the booted image
+let st = bootc status --json | from json
+let booted = $st.status.booted.image
+# Then verify we can extract its metadata via the ostree-container code.
+let metadata = bootc internals ostree-container image metadata --repo=/ostree/repo $"($booted.image.transport):($booted.image.image)" | from json
+assert equal $metadata.mediaType "application/vnd.oci.image.manifest.v1+json"


### PR DESCRIPTION
Today rpm-ostree exposes the `ostree container` verb. As part of taking over from rpm-ostree we need to do the same.

Followup to merging ostree-rs-ext in this repository.

A next step here is for us to start owning the
/usr/libexec/libostree/ext/ostree-container
symlink but that will be a followup.