### PR TITLE
store: Support importing images without `/ostree`

### DIFF
--- a/ostree-ext/src/container/update_detachedmeta.rs
+++ b/ostree-ext/src/container/update_detachedmeta.rs
@@ -70,7 +70,8 @@ pub async fn update_detached_metadata(
             .ok_or_else(|| anyhow!("Image is missing container configuration"))?;
 
         // Find the OSTree commit layer we want to replace
-        let (commit_layer, _, _) = container_store::parse_manifest_layout(&manifest, &config)?;
+        let (commit_layer, _, _) =
+            container_store::parse_ostree_manifest_layout(&manifest, &config)?;
         let commit_layer_idx = manifest
             .layers()
             .iter()


### PR DESCRIPTION
A sticking point keeping ostree in the picture here for containers was SELinux handling. When we started this effort I'd feared rewriting.

But recently we changed things such that we label derived images using the policy from the final root.

This is a relatively small change in code size and complexity, that allows us to import images that don't have "ostree stuff" in them at all, i.e. there's no `/ostree/repo/objects`.

The advantage here is that this significantly simplifies constructing base images.

The main disadvantage today for people who build images this way is that we end up re-labeling and re-checksumming all objects.

But, the real fix for that in the future will be for us to rework things such that we support `security.selinux` for example as native xattrs in the tar stream.