### PR TITLE
two minor bootloader cleanups

### DIFF
--- a/lib/src/bootloader.rs
+++ b/lib/src/bootloader.rs
@@ -7,6 +7,7 @@ use crate::task::Task;
 
 /// The name of the mountpoint for efi (as a subdirectory of /boot, or at the toplevel)
 pub(crate) const EFI_DIR: &str = "efi";
+pub(crate) const ESP_GUID: &str = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B";
 pub(crate) const PREPBOOT_GUID: &str = "9E1A2D38-C612-4316-AA26-8B49521E5A8B";
 pub(crate) const PREPBOOT_LABEL: &str = "PowerPC-PReP-boot";
 #[cfg(target_arch = "powerpc64")]

--- a/lib/src/install/baseline.rs
+++ b/lib/src/install/baseline.rs
@@ -256,10 +256,11 @@ pub(crate) fn install_create_rootfs(
     }
 
     let esp_partno = if super::ARCH_USES_EFI {
+        let esp_guid = crate::bootloader::ESP_GUID;
         partno += 1;
         writeln!(
             &mut partitioning_buf,
-            r#"size={EFIPN_SIZE_MB}MiB, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B, name="EFI-SYSTEM""#
+            r#"size={EFIPN_SIZE_MB}MiB, type={esp_guid}, name="EFI-SYSTEM""#
         )?;
         Some(partno)
     } else {

--- a/lib/src/install/baseline.rs
+++ b/lib/src/install/baseline.rs
@@ -412,7 +412,6 @@ pub(crate) fn install_create_rootfs(
             .run()?;
         let efifs_path = bootfs.join(crate::bootloader::EFI_DIR);
         std::fs::create_dir(&efifs_path).context("Creating efi dir")?;
-        mount::mount(espdev.node.as_str(), &efifs_path)?;
     }
 
     let luks_device = match block_setup {


### PR DESCRIPTION
install: Hoist ESP GUID to a const

Prep for further work.

Signed-off-by: Colin Walters <walters@verbum.org>

---

install: Drop an unnecessary mount

This is handled by bootupd.

Signed-off-by: Colin Walters <walters@verbum.org>

---