### PR TITLE
status: Rework human readable output

### DIFF
--- a/lib/src/glyph.rs
+++ b/lib/src/glyph.rs
@@ -1,0 +1,36 @@
+//! Special Unicode characters used for display with ASCII fallbacks
+//! in case we're not in a UTF-8 locale.
+
+use std::fmt::Display;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) enum Glyph {
+    BlackCircle,
+}
+
+impl Glyph {
+    // TODO: Add support for non-Unicode output
+    #[allow(dead_code)]
+    pub(crate) fn as_ascii(&self) -> &'static str {
+        match self {
+            Glyph::BlackCircle => "*",
+        }
+    }
+
+    pub(crate) fn as_utf8(&self) -> &'static str {
+        match self {
+            Glyph::BlackCircle => "●",
+        }
+    }
+}
+
+impl Display for Glyph {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_utf8())
+    }
+}
+
+#[test]
+fn test_glyph() {
+    assert_eq!(Glyph::BlackCircle.as_utf8(), "●");
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -39,4 +39,5 @@ pub mod spec;
 
 #[cfg(feature = "docgen")]
 mod docgen;
+mod glyph;
 mod imgstorage;


### PR DESCRIPTION
- Add a circle like rpm-ostree
- Add a whitespace line between entries
- Drop not-present entries
- Rework timestamp+version combo; if there's no version, then show the column as `Timestamp`; if there's a version but no timestamp, just omit the timestamp
- Align columns

Closes: https://github.com/containers/bootc/issues/900