### PR TITLE
clippy: Deny `str::len`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ missing_debug_implementations = "deny"
 dead_code = "deny"
 
 [workspace.lints.clippy]
+disallowed_methods = "deny"
 # These should only be in local code
 dbg_macro = "deny"
 todo = "deny"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+disallowed-methods = [
+  # https://github.com/rust-lang/rust-clippy/issues/13434#issuecomment-2484292914
+  { path = "str::len", reason = "use <str>.as_bytes().len() instead" }
+]

--- a/ostree-ext/src/cli.rs
+++ b/ostree-ext/src/cli.rs
@@ -900,7 +900,7 @@ async fn container_store(
 }
 
 fn print_column(s: &str, clen: u16, remaining: &mut terminal_size::Width) {
-    let l: u16 = s.len().try_into().unwrap();
+    let l: u16 = s.chars().count().try_into().unwrap();
     let l = l.min(remaining.0);
     print!("{}", &s[0..l as usize]);
     if clen > 0 {

--- a/ostree-ext/src/tar/import.rs
+++ b/ostree-ext/src/tar/import.rs
@@ -125,7 +125,7 @@ fn parse_object_entry_path(path: &Utf8Path) -> Result<(&str, &Utf8Path, &str)> {
         .parent()
         .and_then(|p| p.file_name())
         .ok_or_else(|| anyhow!("Invalid path (no parent) {}", path))?;
-    if parentname.len() != 2 {
+    if !(parentname.is_ascii() && parentname.as_bytes().len() == 2) {
         return Err(anyhow!("Invalid checksum parent {}", parentname));
     }
     let name = path
@@ -146,7 +146,7 @@ fn parse_checksum(parent: &str, name: &Utf8Path) -> Result<String> {
     // Also take care of the double extension on `.file.xattrs`.
     let checksum_rest = checksum_rest.trim_end_matches(".file");
 
-    if checksum_rest.len() != 62 {
+    if !(checksum_rest.is_ascii() && checksum_rest.as_bytes().len() == 62) {
         return Err(anyhow!("Invalid checksum part {}", checksum_rest));
     }
     let reassembled = format!("{}{}", parent, checksum_rest);


### PR DESCRIPTION
When I was working on some column printing code
with Unicode I got bit by using `str::len`...and
digging in I found that clippy actually just
merged a lint to go the *other* way; more in
the link in the code.

Turning on a lint showed one place that should
have been using `chars().count()` and one that
should have been validating ASCII. Fix those.