### PR TITLE
feat: add thin build profile for embedded applications

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,19 @@ panic = "abort"
 # We assume we're being delivered via e.g. RPM which supports split debuginfo
 debug = true
 
+[profile.thin]
+# drop bootc size when split debuginfo is not available and go a step
+# further in size optimization (when tested from 140mb, to 12mb without 
+# symbols/debuginfo, to 5.8mb with extra optimizations)
+# https://github.com/johnthagen/min-sized-rust
+# cargo build --profile=thin
+inherits = "release"
+debug = false       # Re-strip debug symbols
+strip = true        # Strip symbols from binary
+lto = true          # Use full lto to remove dead code
+opt-level = 's'     # Optimize for size with vector vectorization
+codegen-units = 1   # Reduce number of codegen units to increase optimizations
+
 [profile.releaselto]
 codegen-units = 1
 inherits = "release"


### PR DESCRIPTION
Add a profile that allows squeezing every single bit out of the output executable.

Embedded applications will inevitably require squeezing every single bit out of bootc. Current release executable stands at 140mb due to including debuginfo. This is stripped by the RPM but consumers/forks that do not do that are left with the symbols.

Runs with  `cargo build --profile=thin`. 

Produces an executable with size 5.8mb, current fedora executable of ver 1.1.2 is 7.1mb.

The idea here would be to use for an embedded web installer, that is used by e.g., double clicking an executable or installing an apk file which adds a light EFI executable/bootloader to the device's boot/EFI partition.