### PR TITLE
tests: Add a docstring to fix CI

### DIFF
--- a/ostree-ext/tests/it/main.rs
+++ b/ostree-ext/tests/it/main.rs
@@ -1,3 +1,5 @@
+//! Main integration tests that use the public APIs.
+
 use anyhow::{Context, Result};
 use camino::Utf8Path;
 use cap_std::fs::{Dir, DirBuilder, DirBuilderExt};


### PR DESCRIPTION
It looks like with Rust 1.83, `#[deny(missing_docs)]` started triggering for our integration test. It looks like this is a known thing: https://github.com/rust-lang/rust/issues/130203#issuecomment-2348014975