### PR TITLE
 install: Drop code/test uses of `--security-opt`

### DIFF
--- a/tests-integration/src/install.rs
+++ b/tests-integration/src/install.rs
@@ -11,15 +11,7 @@ use fn_error_context::context;
 use libtest_mimic::Trial;
 use xshell::{cmd, Shell};
 
-pub(crate) const BASE_ARGS: &[&str] = &[
-    "podman",
-    "run",
-    "--rm",
-    "--privileged",
-    "--pid=host",
-    "--security-opt",
-    "label=disable",
-];
+pub(crate) const BASE_ARGS: &[&str] = &["podman", "run", "--rm", "--privileged", "--pid=host"];
 
 // Arbitrary
 const NON_DEFAULT_STATEROOT: &str = "foo";


### PR DESCRIPTION

We think this is unnecessary now; part of improving
the ergonomics of `bootc install` in general, but
especially with the `to-existing-root` path.

Once this lands, at some point later then we
can also remove it from all of the documentation.
But the most safe thing is to leave it in the
docs for a bit longer.

Closes: https://github.com/containers/bootc/issues/928
