### PR TITLE
Use a shared const and helpers for run/ostree-booted

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -17,6 +17,7 @@ use fn_error_context::context;
 use ostree::gio;
 use ostree_container::store::PrepareResult;
 use ostree_ext::container as ostree_container;
+use ostree_ext::container_utils::ostree_booted;
 use ostree_ext::keyfileext::KeyFileExt;
 use ostree_ext::ostree;
 use schemars::schema_for;
@@ -611,9 +612,10 @@ fn prepare_for_write() -> Result<()> {
     if ostree_ext::container_utils::running_in_container() {
         anyhow::bail!("Detected container; this command requires a booted host system.");
     }
-    if !std::path::Path::new("/run/ostree-booted").exists() {
-        anyhow::bail!("This command requires an ostree-booted host system");
-    }
+    anyhow::ensure!(
+        ostree_booted()?,
+        "This command requires an ostree-booted host system"
+    );
     crate::cli::require_root()?;
     ensure_self_unshared_mount_namespace()?;
     if crate::lsm::selinux_enabled()? && !crate::lsm::selinux_ensure_install()? {

--- a/lib/src/status.rs
+++ b/lib/src/status.rs
@@ -5,11 +5,11 @@ use std::io::Read;
 use std::io::Write;
 
 use anyhow::{Context, Result};
-use camino::Utf8Path;
 use fn_error_context::context;
 use ostree::glib;
 use ostree_container::OstreeImageReference;
 use ostree_ext::container as ostree_container;
+use ostree_ext::container_utils::ostree_booted;
 use ostree_ext::keyfileext::KeyFileExt;
 use ostree_ext::oci_spec;
 use ostree_ext::ostree;
@@ -294,7 +294,7 @@ pub(crate) async fn status(opts: super::cli::StatusOpts) -> Result<()> {
         0 | 1 => {}
         o => anyhow::bail!("Unsupported format version: {o}"),
     };
-    let host = if !Utf8Path::new("/run/ostree-booted").try_exists()? {
+    let host = if !ostree_booted()? {
         Default::default()
     } else {
         let sysroot = super::cli::get_storage().await?;

--- a/ostree-ext/src/integrationtest.rs
+++ b/ostree-ext/src/integrationtest.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use crate::container_utils::is_ostree_container;
+use crate::container_utils::{is_ostree_container, ostree_booted};
 use anyhow::{anyhow, Context, Result};
 use camino::Utf8Path;
 use cap_std::fs::Dir;
@@ -21,7 +21,7 @@ use xshell::cmd;
 pub(crate) fn detectenv() -> Result<&'static str> {
     let r = if is_ostree_container()? {
         "ostree-container"
-    } else if Path::new("/run/ostree-booted").exists() {
+    } else if ostree_booted()? {
         "ostree"
     } else if crate::container_utils::running_in_container() {
         "container"


### PR DESCRIPTION
Just a code cleanup.

Closes: https://github.com/containers/bootc/issues/934