### PR TITLE
Minor fixes

### DIFF
--- a/lib/src/boundimage.rs
+++ b/lib/src/boundimage.rs
@@ -233,7 +233,7 @@ mod tests {
 
     #[test]
     fn test_parse_spec_dir() -> Result<()> {
-        const CONTAINER_IMAGE_DIR: &'static str = "usr/share/containers/systemd";
+        const CONTAINER_IMAGE_DIR: &str = "usr/share/containers/systemd";
 
         // Empty dir should return an empty vector
         let td = &cap_std_ext::cap_tempfile::TempDir::new(cap_std::ambient_authority())?;

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -857,10 +857,10 @@ async fn edit(opts: EditOpts) -> Result<()> {
 async fn usroverlay() -> Result<()> {
     // This is just a pass-through today.  At some point we may make this a libostree API
     // or even oxidize it.
-    return Err(Command::new("ostree")
+    Err(Command::new("ostree")
         .args(["admin", "unlock"])
         .exec()
-        .into());
+        .into())
 }
 
 /// Perform process global initialization. This should be called as early as possible
@@ -931,7 +931,7 @@ impl Opt {
                 _ => None,
             };
             if let Some(base_args) = mapped {
-                let base_args = base_args.into_iter().map(OsString::from);
+                let base_args = base_args.iter().map(OsString::from);
                 return Opt::parse_from(base_args.chain(args.map(|i| i.into())));
             }
             Some(first)

--- a/lib/src/image.rs
+++ b/lib/src/image.rs
@@ -105,10 +105,10 @@ pub(crate) async fn list_entrypoint(
 
             table
                 .load_preset(NOTHING)
-                .set_header(vec!["REPOSITORY", "TYPE"]);
+                .set_header(["REPOSITORY", "TYPE"]);
 
             for image in images {
-                table.add_row(vec![image.image, image.image_type.to_string()]);
+                table.add_row([image.image, image.image_type.to_string()]);
             }
 
             println!("{table}");

--- a/lib/src/install/completion.rs
+++ b/lib/src/install/completion.rs
@@ -83,7 +83,7 @@ struct Renamer<'d> {
     to: &'static Utf8Path,
 }
 
-impl<'d> Renamer<'d> {
+impl Renamer<'_> {
     fn _impl_drop(&mut self) -> Result<()> {
         self.dir
             .rename(self.from, self.dir, self.to)
@@ -95,7 +95,7 @@ impl<'d> Renamer<'d> {
     }
 }
 
-impl<'d> Drop for Renamer<'d> {
+impl Drop for Renamer<'_> {
     fn drop(&mut self) {
         let _ = self._impl_drop();
     }

--- a/lib/src/kernel.rs
+++ b/lib/src/kernel.rs
@@ -40,7 +40,7 @@ pub(crate) fn find_first_cmdline_arg<'a>(
 #[test]
 fn test_find_first() {
     let kargs = &["foo=bar", "root=/dev/vda", "blah", "root=/dev/other"];
-    let kargs = || kargs.iter().map(|&s| s);
+    let kargs = || kargs.iter().copied();
     assert_eq!(find_first_cmdline_arg(kargs(), "root"), Some("/dev/vda"));
     assert_eq!(find_first_cmdline_arg(kargs(), "nonexistent"), None);
 }

--- a/lib/src/mount.rs
+++ b/lib/src/mount.rs
@@ -163,7 +163,7 @@ pub(crate) fn open_tree_from_pidns(
         None,
     )
     .context("socketpair")?;
-    const DUMMY_DATA: &[u8] = &[b'!'];
+    const DUMMY_DATA: &[u8] = b"!";
     match unsafe { libc::fork() } {
         0 => {
             // We're in the child. At this point we know we don't have multiple threads, so we

--- a/ostree-ext/src/chunking.rs
+++ b/ostree-ext/src/chunking.rs
@@ -866,13 +866,12 @@ mod test {
             })
             .collect();
 
-        let image_manifest = oci_spec::image::ImageManifestBuilder::default()
+        oci_spec::image::ImageManifestBuilder::default()
             .schema_version(oci_spec::image::SCHEMA_VERSION)
             .config(config)
             .layers(layers)
             .build()
-            .expect("build image manifest");
-        image_manifest
+            .expect("build image manifest")
     }
 
     #[test]

--- a/ostree-ext/src/container/encapsulate.rs
+++ b/ostree-ext/src/container/encapsulate.rs
@@ -392,7 +392,7 @@ pub struct ExportOpts<'m, 'o> {
     pub created: Option<String>,
 }
 
-impl<'m, 'o> ExportOpts<'m, 'o> {
+impl ExportOpts<'_, '_> {
     /// Return the gzip compression level to use, as configured by the export options.
     fn compression(&self) -> Compression {
         if self.skip_compression {

--- a/ostree-ext/src/container/mod.rs
+++ b/ostree-ext/src/container/mod.rs
@@ -387,7 +387,7 @@ impl<'a> ManifestDiff<'a> {
     }
 }
 
-impl<'a> ManifestDiff<'a> {
+impl ManifestDiff<'_> {
     /// Prints the total, removed and added content between two OCI images
     pub fn print(&self) {
         let print_total = self.total;

--- a/ostree-ext/src/fixture.rs
+++ b/ostree-ext/src/fixture.rs
@@ -136,7 +136,7 @@ impl FileDef {
         h.set_mtime(0);
         h.set_uid(self.uid.into());
         h.set_gid(self.gid.into());
-        h.set_mode(self.mode.into());
+        h.set_mode(self.mode);
         match &self.ty {
             FileDefType::Regular(data) => {
                 let data = data.as_bytes();

--- a/ostree-ext/src/ostree_prepareroot.rs
+++ b/ostree-ext/src/ostree_prepareroot.rs
@@ -184,7 +184,7 @@ enabled = false
     for v in ["", d0, d1, d2] {
         let kf = glib::KeyFile::new();
         kf.load_from_data(v, glib::KeyFileFlags::empty()).unwrap();
-        assert_eq!(overlayfs_enabled_in_config(&kf).unwrap(), false);
+        assert!(!overlayfs_enabled_in_config(&kf).unwrap());
     }
 
     let e0 = format!("{d0}\n[root]\ntransient = true");
@@ -194,6 +194,6 @@ enabled = false
     for v in [e0, e1, e2, e3] {
         let kf = glib::KeyFile::new();
         kf.load_from_data(&v, glib::KeyFileFlags::empty()).unwrap();
-        assert_eq!(overlayfs_enabled_in_config(&kf).unwrap(), true);
+        assert!(overlayfs_enabled_in_config(&kf).unwrap());
     }
 }

--- a/ostree-ext/tests/it/main.rs
+++ b/ostree-ext/tests/it/main.rs
@@ -518,7 +518,7 @@ async fn impl_test_container_import_export(chunked: bool) -> Result<()> {
             .cmd()
             .as_ref()
             .unwrap()
-            .get(0)
+            .first()
             .as_ref()
             .unwrap()
             .as_str(),
@@ -671,7 +671,7 @@ async fn test_export_as_container_derived() -> Result<()> {
     let srcpath = src_imgref.name.as_str();
     fixture.generate_test_derived_oci(srcpath, Some(&derived_tag))?;
     let derived_imgref = ImageReference {
-        transport: src_imgref.transport.clone(),
+        transport: src_imgref.transport,
         name: format!("{}:{derived_tag}", src_imgref.name.as_str()),
     };
 


### PR DESCRIPTION
image: Drop unnecessary vec!

No need to allocate here. Drive by cleanup as I was porting
other code to use comfy-table.

Signed-off-by: Colin Walters <walters@verbum.org>

---

tree-wide: Run `cargo clippy --fix`

Nothing important here but eh, let's quiet it.

Signed-off-by: Colin Walters <walters@verbum.org>

---

lib: One more clippy fix

Signed-off-by: Colin Walters <walters@verbum.org>

---
