### PR TITLE
Cmd pdeathsig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,7 @@ name = "bootc-utils"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "rustix",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -1417,6 +1418,7 @@ name = "ostree-ext"
 version = "0.15.3"
 dependencies = [
  "anyhow",
+ "bootc-utils",
  "camino",
  "cap-std-ext",
  "chrono",

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -840,7 +840,8 @@ async fn install_container(
 /// Run a command in the host mount namespace
 pub(crate) fn run_in_host_mountns(cmd: &str) -> Command {
     let mut c = Command::new("/proc/self/exe");
-    c.args(["exec-in-host-mount-namespace", cmd]);
+    c.lifecycle_bind()
+        .args(["exec-in-host-mount-namespace", cmd]);
     c
 }
 

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -117,16 +117,12 @@ pub(crate) fn spawn_editor(tmpf: &tempfile::NamedTempFile) -> Result<()> {
     let argv0 = editor_args
         .next()
         .ok_or_else(|| anyhow::anyhow!("Invalid editor: {editor}"))?;
-    let status = Command::new(argv0)
+    Command::new(argv0)
         .args(editor_args)
         .arg(tmpf.path())
         .lifecycle_bind()
-        .status()
-        .context("Spawning editor")?;
-    if !status.success() {
-        anyhow::bail!("Invoking editor: {editor} failed: {status:?}");
-    }
-    Ok(())
+        .run()
+        .with_context(|| format!("Invoking editor {editor} failed"))
 }
 
 /// Convert a combination of values (likely from CLI parsing) into a signature source

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -5,6 +5,7 @@ use std::process::Command;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use bootc_utils::CommandRunExt;
 #[cfg(feature = "install")]
 use camino::Utf8Path;
 use cap_std_ext::cap_std::fs::Dir;
@@ -119,6 +120,7 @@ pub(crate) fn spawn_editor(tmpf: &tempfile::NamedTempFile) -> Result<()> {
     let status = Command::new(argv0)
         .args(editor_args)
         .arg(tmpf.path())
+        .lifecycle_bind()
         .status()
         .context("Spawning editor")?;
     if !status.success() {

--- a/ostree-ext/Cargo.toml
+++ b/ostree-ext/Cargo.toml
@@ -19,6 +19,7 @@ ostree = { features = ["v2022_6"], version = "0.19.0" }
 
 # Private dependencies
 anyhow = { workspace = true }
+bootc-utils = { path = "../utils" }
 camino = { workspace = true, features = ["serde1"] }
 chrono = { workspace = true }
 olpc-cjson = "0.1.1"

--- a/ostree-ext/src/container/deploy.rs
+++ b/ostree-ext/src/container/deploy.rs
@@ -5,6 +5,7 @@ use std::os::fd::BorrowedFd;
 use std::process::Command;
 
 use anyhow::Result;
+use bootc_utils::CommandRunExt;
 use cap_std_ext::cmdext::CapStdExtCommandExt;
 use fn_error_context::context;
 use ocidir::cap_std::fs::Dir;
@@ -148,6 +149,7 @@ pub async fn deploy(
             let st = Command::new("/proc/self/exe")
                 .args(["internals", "bootc-install-completion", ".", stateroot])
                 .cwd_dir(sysroot_dir.try_clone()?)
+                .lifecycle_bind()
                 .status()?;
             if !st.success() {
                 anyhow::bail!("Failed to complete bootc install");

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/containers/bootc"
 
 [dependencies]
 anyhow = { workspace = true }
+rustix = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tempfile = { workspace = true }


### PR DESCRIPTION
utils: Add a lifecycle_bind helper for Command

In almost all children we fork, we want the child to reliably
exit if we do (e.g. especially if we panic). The Linux
PR_SET_PDEATHSIG is just great for this.

Signed-off-by: Colin Walters <walters@verbum.org>

---

utils: Use `run` helper for editor

I just happened to glance at this code, this gives us stderr
in the error, etc.

Signed-off-by: Colin Walters <walters@verbum.org>

---
