### PR TITLE
Drop podman host exec

### DIFF
--- a/lib/src/podman.rs
+++ b/lib/src/podman.rs
@@ -30,14 +30,12 @@ pub(crate) struct ImageListEntry {
 #[cfg(feature = "install")]
 pub(crate) fn imageid_to_digest(imgid: &str) -> Result<String> {
     use bootc_utils::CommandRunExt;
-    let o: Vec<Inspect> = std::process::Command::new("podman")
-        .args(["inspect", imgid])
+    // Use skopeo here as that's our current baseline dependency.
+    let o: Inspect = std::process::Command::new("skopeo")
+        .arg("inspect")
+        .arg(format!("containers-storage:{imgid}"))
         .run_and_parse_json()?;
-    let i = o
-        .into_iter()
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("No images returned for inspect"))?;
-    Ok(i.digest)
+    Ok(o.digest)
 }
 
 /// Return true if there is apparently an active container store at the target path.

--- a/lib/src/podman.rs
+++ b/lib/src/podman.rs
@@ -30,7 +30,7 @@ pub(crate) struct ImageListEntry {
 #[cfg(feature = "install")]
 pub(crate) fn imageid_to_digest(imgid: &str) -> Result<String> {
     use bootc_utils::CommandRunExt;
-    let o: Vec<Inspect> = crate::install::run_in_host_mountns("podman")
+    let o: Vec<Inspect> = std::process::Command::new("podman")
         .args(["inspect", imgid])
         .run_and_parse_json()?;
     let i = o


### PR DESCRIPTION
lib: Drop usage of hacky run_in_host_mount_ns

What we're doing here is a bit gross because while we're
changing the mountns, other things (especially networking)
will be inherited from our container, creating an ill-defined
mess. If we do need true host code execution then we should
actually use systemd-run or so.

But we don't need that here - now that we've been automatically
ensuring the `/var/lib/containers` mount, we can use the version
of podman in the container image here.

Signed-off-by: Colin Walters <walters@verbum.org>

---

install: Use skopeo instead of podman

Right now we depend on both in general (the ostree-container side uses
skopeo, the logically bound images use podman), but today LBIs are
a "soft" dependency.

Let's use skopeo here for consistency.

Signed-off-by: Colin Walters <walters@verbum.org>

---
