### PR TITLE
Filesystem doc

### DIFF
--- a/docs/src/filesystem-storage.md
+++ b/docs/src/filesystem-storage.md
@@ -58,7 +58,7 @@ The flattened tree is constructed and committed into the
 `ostree/container/image` namespace.  The commit metadata also includes
 the OCI manifest and config objects.
 
-This is implmented in the [ostree-rs-ext/container module](https://docs.rs/ostree-ext/latest/ostree_ext/container/index.html).
+This is implemented in the [ostree-rs-ext/container module](https://docs.rs/ostree-ext/latest/ostree_ext/container/index.html).
 
 ### SELinux labeling
 

--- a/docs/src/filesystem.md
+++ b/docs/src/filesystem.md
@@ -186,12 +186,14 @@ To do this, set the
 transient = true
 ```
 
-option in `prepare-root.conf`.  In particular this will allow software to
+option in `/usr/lib/ostree/prepare-root.conf`.  In particular this will allow software to
 write (transiently, i.e. until the next reboot) to all top-level directories,
 including `/usr` and `/opt`, with symlinks to `/var` for content that should
 persist.
 
 This can be combined with `etc.transient` as well (below).
+
+More on prepare-root: <https://ostreedev.github.io/ostree/man/ostree-prepare-root.html>
 
 ## Enabling transient etc
 
@@ -205,9 +207,11 @@ the
 transient = true
 ```
 
-option in `prepare-root.conf`.
+option in `/usr/lib/ostree/prepare-root.conf`.
 
 This can be combined with `root.transient` as well (above).
+
+More on prepare-root: <https://ostreedev.github.io/ostree/man/ostree-prepare-root.html>
 
 ## Enabling state overlays
 

--- a/docs/src/filesystem.md
+++ b/docs/src/filesystem.md
@@ -80,7 +80,7 @@ across upgrades.  In a nutshell:
 - The diff between current and previous `/etc` is applied to the new `/etc`
 - Locally modified files in `/etc` different from the default `/usr/etc` (of the same deployment) will be retained
 
-The implmentation of this defaults to being executed by `ostree-finalize-staged.service`
+The implementation of this defaults to being executed by `ostree-finalize-staged.service`
 at shutdown time, before the new bootloader entry is created.
 
 The rationale for this design is that in practice today, many components of a Linux system end up shipping
@@ -99,7 +99,7 @@ For more on configuration file best practices, see [Building](building/guidance.
 ### `/usr/etc`
 
 The `/usr/etc` tree is generated client side and contains the default container image's
-view of `/etc`. This should generally be considered an internal implmentation detail
+view of `/etc`. This should generally be considered an internal implementation detail
 of bootc/ostree. Do *not* explicitly put files into this location, it can create
 undefined behavior. There is a check for this in `bootc container lint`.
 

--- a/docs/src/filesystem.md
+++ b/docs/src/filesystem.md
@@ -70,7 +70,8 @@ in derived builds.
 ## `/etc`
 
 The `/etc` directory contains mutable persistent state by default; however,
-it is suppported to enable the [`etc.transient` config option](https://ostreedev.github.io/ostree/man/ostree-prepare-root.html).
+it is suppported to enable the [`etc.transient` config option](https://ostreedev.github.io/ostree/man/ostree-prepare-root.html),
+see below as well.
 
 When in persistent mode, it inherits the OSTree semantics of [performing a 3-way merge](https://ostreedev.github.io/ostree/atomic-upgrades/#assembling-a-new-deployment-directory)
 across upgrades.  In a nutshell:
@@ -189,6 +190,24 @@ option in `prepare-root.conf`.  In particular this will allow software to
 write (transiently, i.e. until the next reboot) to all top-level directories,
 including `/usr` and `/opt`, with symlinks to `/var` for content that should
 persist.
+
+This can be combined with `etc.transient` as well (below).
+
+## Enabling transient etc
+
+The default (per above) is to have `/etc` persist. If however you do
+not need to use it for any per-machine state, then enabling a transient
+`/etc` is a great way to reduce the amount of possible state drift. Set
+the
+
+```toml
+[etc]
+transient = true
+```
+
+option in `prepare-root.conf`.
+
+This can be combined with `root.transient` as well (above).
 
 ## Enabling state overlays
 

--- a/docs/src/filesystem.md
+++ b/docs/src/filesystem.md
@@ -95,6 +95,13 @@ would require external intervention to apply.
 
 For more on configuration file best practices, see [Building](building/guidance.md).
 
+### `/usr/etc`
+
+The `/usr/etc` tree is generated client side and contains the default container image's
+view of `/etc`. This should generally be considered an internal implmentation detail
+of bootc/ostree. Do *not* explicitly put files into this location, it can create
+undefined behavior. There is a check for this in `bootc container lint`.
+
 ## `/var`
 
 Content in `/var` persists by default; it is however supported to make it or subdirectories


### PR DESCRIPTION
filesystem: Doc usr/etc

Came up in review.

Signed-off-by: Colin Walters <walters@verbum.org>

---

filesystem: Doc etc.transient

I noticed this was missing.

Signed-off-by: Colin Walters <walters@verbum.org>

---

doc: Expand on prepare-root

Per review.

Signed-off-by: Colin Walters <walters@verbum.org>

---
