### PR TITLE
ci: remove python checking and fix labeler action error

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,4 +9,5 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
+      - uses: actions/checkout@v4
+      - uses: actions/labeler@v5

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,8 +1,0 @@
-name: Python static analysis
-on: [push, pull_request]
-jobs:
-  ruff:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1


### PR DESCRIPTION
This PR includes:

- No python code in the repo any more, do not need python checking in CI.
- Fix "The configuration file (path: .github/labeler.yml) was not found locally" labeler error.