### PR TITLE
Various updates for `--progress-fd`

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -55,6 +55,7 @@
 # Experimental features
 
 - [bootc image](experimental-bootc-image.md)
+- [--progress-fd](experimental-progress-fd.md)
 
 # More information
 

--- a/docs/src/bootc-via-api.md
+++ b/docs/src/bootc-via-api.md
@@ -7,7 +7,7 @@ are stable and will not change.
 ## Using `bootc edit` and `bootc status --json`
 
 While bootc does not depend on Kubernetes, it does currently
-also offere a Kubernetes *style* API, especially oriented
+also offer a Kubernetes *style* API, especially oriented
 towards the [spec and status and other conventions](https://kubernetes.io/docs/reference/using-api/api-concepts/).
 
 In general, most use cases of driving bootc via API are probably

--- a/docs/src/experimental-progress-fd.md
+++ b/docs/src/experimental-progress-fd.md
@@ -12,9 +12,8 @@ The format of data output over `--progress-fd` is [JSON Lines](https://jsonlines
 which is a series of JSON objects separated by newlines (the intermediate
 JSON content is guaranteed not to contain a literal newline).
 
-The current API version is `org.containers.bootc/progress/v1`. You can find
-the JSON schema describing this version here:
-[progress-v1.schema.json](progress-v1.schema.json).
+You can find the JSON schema describing this version here:
+[progress-v0.schema.json](progress-v0.schema.json).
 
 Deploying a new image with either switch or upgrade consists
 of three stages: `pulling`, `importing`, and `staging`. The `pulling` step

--- a/docs/src/experimental-progress-fd.md
+++ b/docs/src/experimental-progress-fd.md
@@ -1,0 +1,33 @@
+
+# Interactive progress with `--progress-fd`
+
+This is an experimental feature; tracking issue: <https://github.com/containers/bootc/issues/1016>
+
+While the `bootc status` tooling allows a client to discover the state
+of the system, during interactive changes such as `bootc upgrade`
+or `bootc switch` it is possible to monitor the status of downloads
+or other operations at a fine-grained level with `-progress-fd`.
+
+The format of data output over `--progress-fd` is [JSON Lines](https://jsonlines.org)
+which is a series of JSON objects separated by newlines (the intermediate
+JSON content is guaranteed not to contain a literal newline).
+
+The current API version is `org.containers.bootc/progress/v1`. You can find
+the JSON schema describing this version here:
+[progress-v1.schema.json](progress-v1.schema.json).
+
+Deploying a new image with either switch or upgrade consists
+of three stages: `pulling`, `importing`, and `staging`. The `pulling` step
+downloads the image from the registry, offering per-layer and progress in
+each message. The `importing` step imports the image into storage and consists
+of a single step. Finally, `staging` runs a variety of staging
+tasks. Currently, they are staging the image to disk, pulling bound images,
+and removing old images.
+
+Note that new stages or fields may be added at any time.
+
+Importing and staging are affected by disk speed and the total image size. Pulling
+is affected by network speed and how many layers invalidate between pulls.
+Therefore, a large image with a good caching strategy will have longer
+importing and staging times, and a small bespoke container image will have
+negligible importing and staging times.

--- a/docs/src/progress-v0.schema.json
+++ b/docs/src/progress-v0.schema.json
@@ -4,10 +4,28 @@
   "description": "An event emitted as JSON.",
   "oneOf": [
     {
+      "type": "object",
+      "required": [
+        "type",
+        "version"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Start"
+          ]
+        },
+        "version": {
+          "description": "The semantic version of the progress protocol.",
+          "type": "string"
+        }
+      }
+    },
+    {
       "description": "An incremental update to a container image layer download",
       "type": "object",
       "required": [
-        "api_version",
         "bytes",
         "bytes_cached",
         "bytes_total",
@@ -21,10 +39,6 @@
         "type"
       ],
       "properties": {
-        "api_version": {
-          "description": "The version of the progress event format.",
-          "type": "string"
-        },
         "bytes": {
           "description": "The number of bytes already fetched.",
           "type": "integer",
@@ -92,7 +106,6 @@
       "description": "An incremental update with discrete steps",
       "type": "object",
       "required": [
-        "api_version",
         "description",
         "id",
         "steps",
@@ -103,10 +116,6 @@
         "type"
       ],
       "properties": {
-        "api_version": {
-          "description": "The version of the progress event format.",
-          "type": "string"
-        },
         "description": {
           "description": "A human readable description of the task if i18n is not available.",
           "type": "string"

--- a/docs/src/progress-v1.schema.json
+++ b/docs/src/progress-v1.schema.json
@@ -1,0 +1,230 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Event",
+  "description": "An event emitted as JSON.",
+  "oneOf": [
+    {
+      "description": "An incremental update to a container image layer download",
+      "type": "object",
+      "required": [
+        "api_version",
+        "bytes",
+        "bytes_cached",
+        "bytes_total",
+        "description",
+        "id",
+        "steps",
+        "steps_cached",
+        "steps_total",
+        "subtasks",
+        "task",
+        "type"
+      ],
+      "properties": {
+        "api_version": {
+          "description": "The version of the progress event format.",
+          "type": "string"
+        },
+        "bytes": {
+          "description": "The number of bytes already fetched.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "bytes_cached": {
+          "description": "The number of bytes fetched by a previous run.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "bytes_total": {
+          "description": "Total number of bytes. If zero, then this should be considered \"unspecified\".",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "description": {
+          "description": "A human readable description of the task if i18n is not available.",
+          "type": "string"
+        },
+        "id": {
+          "description": "A human and machine readable unique identifier for the task (e.g., the image name). For tasks that only happen once, it can be set to the same value as task.",
+          "type": "string"
+        },
+        "steps": {
+          "description": "The initial position of progress.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "steps_cached": {
+          "description": "The number of steps fetched by a previous run.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "steps_total": {
+          "description": "The total number of steps (e.g. container image layers, RPMs)",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "subtasks": {
+          "description": "The currently running subtasks.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SubTaskBytes"
+          }
+        },
+        "task": {
+          "description": "A machine readable type (e.g., pulling) for the task (used for i18n and UI customization).",
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "ProgressBytes"
+          ]
+        }
+      }
+    },
+    {
+      "description": "An incremental update with discrete steps",
+      "type": "object",
+      "required": [
+        "api_version",
+        "description",
+        "id",
+        "steps",
+        "steps_cached",
+        "steps_total",
+        "subtasks",
+        "task",
+        "type"
+      ],
+      "properties": {
+        "api_version": {
+          "description": "The version of the progress event format.",
+          "type": "string"
+        },
+        "description": {
+          "description": "A human readable description of the task if i18n is not available.",
+          "type": "string"
+        },
+        "id": {
+          "description": "A human and machine readable unique identifier for the task (e.g., the image name). For tasks that only happen once, it can be set to the same value as task.",
+          "type": "string"
+        },
+        "steps": {
+          "description": "The initial position of progress.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "steps_cached": {
+          "description": "The number of steps fetched by a previous run.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "steps_total": {
+          "description": "The total number of steps (e.g. container image layers, RPMs)",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "subtasks": {
+          "description": "The currently running subtasks.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SubTaskStep"
+          }
+        },
+        "task": {
+          "description": "A machine readable type (e.g., pulling) for the task (used for i18n and UI customization).",
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "ProgressSteps"
+          ]
+        }
+      }
+    }
+  ],
+  "definitions": {
+    "SubTaskBytes": {
+      "description": "An incremental update to e.g. a container image layer download. The first time a given \"subtask\" name is seen, a new progress bar should be created. If bytes == bytes_total, then the subtask is considered complete.",
+      "type": "object",
+      "required": [
+        "bytes",
+        "bytesCached",
+        "bytesTotal",
+        "description",
+        "id",
+        "subtask"
+      ],
+      "properties": {
+        "bytes": {
+          "description": "Updated byte level progress",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "bytesCached": {
+          "description": "The number of bytes fetched by a previous run (e.g., zstd_chunked).",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "bytesTotal": {
+          "description": "Total number of bytes",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "description": {
+          "description": "A human readable description of the task if i18n is not available. (e.g., \"OSTree Chunk:\", \"Derived Layer:\")",
+          "type": "string"
+        },
+        "id": {
+          "description": "A human and machine readable identifier for the task (e.g., ostree chunk/layer hash).",
+          "type": "string"
+        },
+        "subtask": {
+          "description": "A machine readable type for the task (used for i18n). (e.g., \"ostree_chunk\", \"ostree_derived\")",
+          "type": "string"
+        }
+      }
+    },
+    "SubTaskStep": {
+      "description": "Marks the beginning and end of a dictrete step",
+      "type": "object",
+      "required": [
+        "completed",
+        "description",
+        "id",
+        "subtask"
+      ],
+      "properties": {
+        "completed": {
+          "description": "Starts as false when beginning to execute and turns true when completed.",
+          "type": "boolean"
+        },
+        "description": {
+          "description": "A human readable description of the task if i18n is not available. (e.g., \"OSTree Chunk:\", \"Derived Layer:\")",
+          "type": "string"
+        },
+        "id": {
+          "description": "A human and machine readable identifier for the task (e.g., ostree chunk/layer hash).",
+          "type": "string"
+        },
+        "subtask": {
+          "description": "A machine readable type for the task (used for i18n). (e.g., \"ostree_chunk\", \"ostree_derived\")",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -38,7 +38,7 @@ pub(crate) struct ProgressOptions {
     /// Interactive progress will be written to this file descriptor as "JSON lines"
     /// format, where each value is separated by a newline.
     #[clap(long)]
-    pub(crate) json_fd: Option<RawProgressFd>,
+    pub(crate) progress_fd: Option<RawProgressFd>,
 }
 
 impl TryFrom<ProgressOptions> for ProgressWriter {
@@ -46,7 +46,7 @@ impl TryFrom<ProgressOptions> for ProgressWriter {
 
     fn try_from(value: ProgressOptions) -> Result<Self> {
         let r = value
-            .json_fd
+            .progress_fd
             .map(TryInto::try_into)
             .transpose()?
             .unwrap_or_default();

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -37,7 +37,7 @@ pub(crate) struct ProgressOptions {
     ///
     /// Interactive progress will be written to this file descriptor as "JSON lines"
     /// format, where each value is separated by a newline.
-    #[clap(long)]
+    #[clap(long, hide = true)]
     pub(crate) progress_fd: Option<RawProgressFd>,
 }
 

--- a/lib/src/deploy.rs
+++ b/lib/src/deploy.rs
@@ -21,7 +21,7 @@ use ostree_ext::ostree::{self, Sysroot};
 use ostree_ext::sysroot::SysrootLock;
 use ostree_ext::tokio_util::spawn_blocking_cancellable_flatten;
 
-use crate::progress_jsonl::{Event, ProgressWriter, SubTaskBytes, SubTaskStep, API_VERSION};
+use crate::progress_jsonl::{Event, ProgressWriter, SubTaskBytes, SubTaskStep};
 use crate::spec::ImageReference;
 use crate::spec::{BootOrder, HostSpec};
 use crate::status::labels_of_config;
@@ -214,7 +214,6 @@ async fn handle_layer_progress_print(
                         subtask.bytes = layer_size;
                         subtasks.push(subtask.clone());
                         prog.send(Event::ProgressBytes {
-                            api_version: API_VERSION.into(),
                             task: "pulling".into(),
                             description: format!("Pulling Image: {digest}").into(),
                             id: (*digest).into(),
@@ -245,7 +244,6 @@ async fn handle_layer_progress_print(
                     byte_bar.set_position(bytes.fetched);
                     subtask.bytes = byte_bar.position();
                     prog.send_lossy(Event::ProgressBytes {
-                        api_version: API_VERSION.into(),
                         task: "pulling".into(),
                         description: format!("Pulling Image: {digest}").into(),
                         id: (*digest).into(),
@@ -283,7 +281,6 @@ async fn handle_layer_progress_print(
     // use as a heuristic to begin import progress
     // Cannot be lossy or it is dropped
     prog.send(Event::ProgressSteps {
-        api_version: API_VERSION.into(),
         task: "importing".into(),
         description: "Importing Image".into(),
         id: (*digest).into(),
@@ -358,7 +355,6 @@ pub(crate) async fn pull(
     let prog = printer.await?;
     // Both the progress and the import are done, so import is done as well
     prog.send(Event::ProgressSteps {
-        api_version: API_VERSION.into(),
         task: "importing".into(),
         description: "Importing Image".into(),
         id: digest_imp.clone().as_ref().into(),
@@ -573,7 +569,6 @@ pub(crate) async fn stage(
     };
     let mut subtasks = vec![];
     prog.send(Event::ProgressSteps {
-        api_version: API_VERSION.into(),
         task: "staging".into(),
         description: "Deploying Image".into(),
         id: image.manifest_digest.clone().as_ref().into(),
@@ -596,7 +591,6 @@ pub(crate) async fn stage(
     subtask.description = "Deploying Image".into();
     subtask.completed = false;
     prog.send(Event::ProgressSteps {
-        api_version: API_VERSION.into(),
         task: "staging".into(),
         description: "Deploying Image".into(),
         id: image.manifest_digest.clone().as_ref().into(),
@@ -627,7 +621,6 @@ pub(crate) async fn stage(
     subtask.description = "Pulling Bound Images".into();
     subtask.completed = false;
     prog.send(Event::ProgressSteps {
-        api_version: API_VERSION.into(),
         task: "staging".into(),
         description: "Deploying Image".into(),
         id: image.manifest_digest.clone().as_ref().into(),
@@ -650,7 +643,6 @@ pub(crate) async fn stage(
     subtask.description = "Removing old images".into();
     subtask.completed = false;
     prog.send(Event::ProgressSteps {
-        api_version: API_VERSION.into(),
         task: "staging".into(),
         description: "Deploying Image".into(),
         id: image.manifest_digest.clone().as_ref().into(),
@@ -674,7 +666,6 @@ pub(crate) async fn stage(
     subtask.completed = true;
     subtasks.push(subtask.clone());
     prog.send(Event::ProgressSteps {
-        api_version: API_VERSION.into(),
         task: "staging".into(),
         description: "Deploying Image".into(),
         id: image.manifest_digest.clone().as_ref().into(),

--- a/lib/src/progress_jsonl.rs
+++ b/lib/src/progress_jsonl.rs
@@ -2,6 +2,7 @@
 //! see <https://jsonlines.org/>.
 
 use anyhow::Result;
+use schemars::JsonSchema;
 use serde::Serialize;
 use std::borrow::Cow;
 use std::os::fd::{FromRawFd, OwnedFd, RawFd};
@@ -20,7 +21,7 @@ pub const API_VERSION: &str = "org.containers.bootc.progress/v1";
 /// An incremental update to e.g. a container image layer download.
 /// The first time a given "subtask" name is seen, a new progress bar should be created.
 /// If bytes == bytes_total, then the subtask is considered complete.
-#[derive(Debug, serde::Serialize, serde::Deserialize, Default, Clone)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Default, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SubTaskBytes<'t> {
     /// A machine readable type for the task (used for i18n).
@@ -44,7 +45,7 @@ pub struct SubTaskBytes<'t> {
 }
 
 /// Marks the beginning and end of a dictrete step
-#[derive(Debug, serde::Serialize, serde::Deserialize, Default, Clone)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Default, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SubTaskStep<'t> {
     /// A machine readable type for the task (used for i18n).
@@ -64,7 +65,7 @@ pub struct SubTaskStep<'t> {
 }
 
 /// An event emitted as JSON.
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, JsonSchema)]
 #[serde(
     tag = "type",
     rename_all = "PascalCase",

--- a/tests/booted/test-image-pushpull-upgrade.nu
+++ b/tests/booted/test-image-pushpull-upgrade.nu
@@ -60,7 +60,7 @@ RUN echo test content > /usr/share/blah.txt
     try { systemctl kill test-cat-progress }
     systemd-run -u test-cat-progress -- /bin/bash -c $"exec cat ($progress_fifo) > ($progress_json)"
     # nushell doesn't do fd passing right now either, so run via bash
-    bash -c $"bootc switch --json-fd 3 --transport containers-storage localhost/bootc-derived 3>($progress_fifo)"
+    bash -c $"bootc switch --progress-fd 3 --transport containers-storage localhost/bootc-derived 3>($progress_fifo)"
     # Now, let's do some checking of the progress json
     let progress = open --raw $progress_json | from json -o
     sanity_check_switch_progress_json $progress

--- a/tests/booted/test-image-pushpull-upgrade.nu
+++ b/tests/booted/test-image-pushpull-upgrade.nu
@@ -75,10 +75,12 @@ RUN echo test content > /usr/share/blah.txt
 
 # This just does some basic verification of the progress JSON
 def sanity_check_switch_progress_json [data] {
-    let first = $data.0;
     let event_count = $data | length
-    assert equal $first.type ProgressBytes
-    let steps = $first.stepsTotal
+    # The first one should always be a start event
+    let first = $data.0;
+    assert equal $first.type Start
+    let second = $data.1
+    let steps = $second.stepsTotal
     mut i = 0
     for elt in $data {
         if $elt.type != "ProgressBytes" {

--- a/xtask/src/xtask.rs
+++ b/xtask/src/xtask.rs
@@ -147,10 +147,14 @@ fn update_generated(sh: &Shell) -> Result<()> {
         )
         .run()?;
     }
-    let schema = cmd!(sh, "cargo run -q -- internals print-json-schema").read()?;
-    let target = "docs/src/host-v1.schema.json";
-    std::fs::write(target, &schema)?;
-    println!("Updated {target}");
+    for (of, target) in [
+        ("host", "docs/src/host-v1.schema.json"),
+        ("progress", "docs/src/progress-v1.schema.json"),
+    ] {
+        let schema = cmd!(sh, "cargo run -q -- internals print-json-schema --of={of}").read()?;
+        std::fs::write(target, &schema)?;
+        println!("Updated {target}");
+    }
     Ok(())
 }
 

--- a/xtask/src/xtask.rs
+++ b/xtask/src/xtask.rs
@@ -149,7 +149,7 @@ fn update_generated(sh: &Shell) -> Result<()> {
     }
     for (of, target) in [
         ("host", "docs/src/host-v1.schema.json"),
-        ("progress", "docs/src/progress-v1.schema.json"),
+        ("progress", "docs/src/progress-v0.schema.json"),
     ] {
         let schema = cmd!(sh, "cargo run -q -- internals print-json-schema --of={of}").read()?;
         std::fs::write(target, &schema)?;


### PR DESCRIPTION
deploy: Avoid cloning progress

Have the printer take ownership and return it. This is generally
prep for making the writer more stateful which will make it easier
to work with.

Signed-off-by: Colin Walters <walters@verbum.org>

---

cli: Rename --json-fd to --progress-fd

The format is not as important as what the option *does*. There's
multiple things that can be JSON, but this is specifically
about dynamic progress information.

Signed-off-by: Colin Walters <walters@verbum.org>

---

cli: Make --progress-fd hide=true for now

We're still debating some of the interface/semantics here
so let's mark this as hidden.

Signed-off-by: Colin Walters <walters@verbum.org>

---

docs: Describe `--progress-fd`, add rendered JSON schema

Signed-off-by: Antheas Kapenekakis <git@antheas.dev>
Signed-off-by: Colin Walters <walters@verbum.org>

---