### PR TITLE
copr: fix Unknown argument "builddep" for command "dnf5"

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,4 +1,5 @@
 srpm:
+	dnf5 -y install 'dnf5-command(builddep)'
 	dnf -y install dnf-utils git
 	# similar to https://github.com/actions/checkout/issues/760, but for COPR
 	git config --global --add safe.directory '*'


### PR DESCRIPTION
The copr build environment looks upgrade to Fedora 41 now, dnf5 has been used since that. That caused `dnf builddep` command error.
```
dnf -y builddep ./contrib/packaging/bootc.spec
Unknown argument "builddep" for command "dnf5". Add "--help" for more information about the arguments.
It could be a command provided by a plugin, try: dnf5 install 'dnf5-command(builddep)'
make: *** [/mnt/workdir-c4js6f0t/bootc/.copr/Makefile:5: srpm] Error 2
```

dnf5 needs `dnf5-command(builddep)` installed to run "dnf builddep"

The copr build failure log: https://log-detective.com/contribute/copr/8384952/srpm-builds#