### PR TITLE
WIP: Add progress for install

### DIFF
--- a/lib/src/progress_jsonl.rs
+++ b/lib/src/progress_jsonl.rs
@@ -2,7 +2,7 @@
 //! see <https://jsonlines.org/>.
 
 use anyhow::Result;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::os::fd::{FromRawFd, OwnedFd, RawFd};
 use std::str::FromStr;
@@ -131,7 +131,8 @@ pub enum Event<'t> {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
 pub(crate) struct RawProgressFd(RawFd);
 
 impl FromStr for RawProgressFd {


### PR DESCRIPTION
It turns out to be *really* hard to make this work with my default dev setup of podman-machine...FIFOs don't work over virtiofs for unsurprising reasons, and podman doesn't do fd passing with podman-remote.

I think the best fix is to add pipe fd passing with podman remote and have it act as a copying proxy.