### PR TITLE
ci: labeler: use globstar where applicable

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,16 +1,18 @@
 documentation:
 - changed-files:
   - any-glob-to-any-file:
-    - 'docs/*'
+    - 'docs/**'
     - README.md
 
 # Automatically bypass most CI for doc-only changes
 control/skip-ci:
 - changed-files:
   - any-glob-to-all-files:
-    - 'docs/*'
+    - 'docs/**'
     - README.md
 
 area/install:
 - changed-files:
-  - any-glob-to-any-file: 'lib/src/install*'
+  - any-glob-to-any-file:
+      - 'lib/src/install.rs'
+      - 'lib/src/install/**'


### PR DESCRIPTION
It appears the single glob '*' doesn't match recursively, so use the
globstar '**' where we want to match anything within a subtree

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
