### PR TITLE
`install` feature is always on, add `install-to-disk`

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -53,9 +53,11 @@ similar-asserts = { workspace = true }
 static_assertions = { workspace = true }
 
 [features]
-default = ["install"]
-# This feature enables `bootc install`.  Disable if you always want to use an external installer.
-install = []
+default = ["install-to-disk"]
+# This feature enables `bootc install to-disk`, which is considered just a "demo"
+# or reference installer; we expect most nontrivial use cases to be using
+# `bootc install to-filesystem`.
+install-to-disk = []
 # This featuares enables `bootc internals publish-rhsm-facts` to integrate with
 # Red Hat Subscription Manager
 rhsm = []

--- a/lib/src/bootloader.rs
+++ b/lib/src/bootloader.rs
@@ -7,8 +7,11 @@ use crate::task::Task;
 
 /// The name of the mountpoint for efi (as a subdirectory of /boot, or at the toplevel)
 pub(crate) const EFI_DIR: &str = "efi";
+#[cfg(feature = "install-to-disk")]
 pub(crate) const ESP_GUID: &str = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B";
+#[cfg(feature = "install-to-disk")]
 pub(crate) const PREPBOOT_GUID: &str = "9E1A2D38-C612-4316-AA26-8B49521E5A8B";
+#[cfg(feature = "install-to-disk")]
 pub(crate) const PREPBOOT_LABEL: &str = "PowerPC-PReP-boot";
 #[cfg(target_arch = "powerpc64")]
 /// We make a best-effort to support MBR partitioning too.

--- a/lib/src/boundimage.rs
+++ b/lib/src/boundimage.rs
@@ -10,7 +10,6 @@ use camino::Utf8Path;
 use cap_std_ext::cap_std::fs::Dir;
 use cap_std_ext::dirext::CapStdExtDirExt;
 use fn_error_context::context;
-#[cfg(feature = "install")]
 use ostree_ext::containers_image_proxy;
 use ostree_ext::ostree::Deployment;
 
@@ -33,7 +32,6 @@ pub(crate) struct BoundImage {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-#[cfg(feature = "install")]
 pub(crate) struct ResolvedBoundImage {
     pub(crate) image: String,
     pub(crate) digest: String,
@@ -104,7 +102,6 @@ pub(crate) fn query_bound_images(root: &Dir) -> Result<Vec<BoundImage>> {
     Ok(bound_images)
 }
 
-#[cfg(feature = "install")]
 impl ResolvedBoundImage {
     #[context("resolving bound image {}", src.image)]
     pub(crate) async fn from_image(src: &BoundImage) -> Result<Self> {

--- a/lib/src/install/baseline.rs
+++ b/lib/src/install/baseline.rs
@@ -21,12 +21,14 @@ use clap::ValueEnum;
 use fn_error_context::context;
 use serde::{Deserialize, Serialize};
 
+use super::config::Filesystem;
 use super::MountSpec;
 use super::RootSetup;
 use super::State;
 use super::RUN_BOOTC;
 use super::RW_KARG;
 use crate::mount;
+#[cfg(feature = "install-to-disk")]
 use crate::mount::is_mounted_in_pid1_mountns;
 use crate::task::Task;
 
@@ -35,20 +37,6 @@ pub(crate) const BOOTPN_SIZE_MB: u32 = 510;
 pub(crate) const EFIPN_SIZE_MB: u32 = 512;
 /// The GPT type for "linux"
 pub(crate) const LINUX_PARTTYPE: &str = "0FC63DAF-8483-4772-8E79-3D69D8477DE4";
-
-#[derive(clap::ValueEnum, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub(crate) enum Filesystem {
-    Xfs,
-    Ext4,
-    Btrfs,
-}
-
-impl Display for Filesystem {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.to_possible_value().unwrap().get_name().fmt(f)
-    }
-}
 
 #[derive(clap::ValueEnum, Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -104,6 +92,7 @@ impl BlockSetup {
     }
 }
 
+#[cfg(feature = "install-to-disk")]
 fn mkfs<'a>(
     dev: &str,
     fs: Filesystem,
@@ -143,6 +132,7 @@ fn mkfs<'a>(
 }
 
 #[context("Creating rootfs")]
+#[cfg(feature = "install-to-disk")]
 pub(crate) fn install_create_rootfs(
     state: &State,
     opts: InstallBlockDeviceOpts,

--- a/lib/src/kargs.rs
+++ b/lib/src/kargs.rs
@@ -53,7 +53,6 @@ pub(crate) fn get_kargs_in_root(d: &Dir, sys_arch: &str) -> Result<Vec<String>> 
 }
 
 /// Load kargs.d files from the target ostree commit root
-#[cfg(feature = "install")]
 pub(crate) fn get_kargs_from_ostree_root(
     repo: &ostree::Repo,
     root: &ostree::RepoFile,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -30,17 +30,11 @@ mod utils;
 #[cfg(feature = "docgen")]
 mod docgen;
 
-#[cfg(feature = "install")]
 mod blockdev;
-#[cfg(feature = "install")]
 mod bootloader;
-#[cfg(feature = "install")]
 mod containerenv;
-#[cfg(feature = "install")]
 mod install;
-#[cfg(feature = "install")]
 mod kernel;
-#[cfg(feature = "install")]
 pub(crate) mod mount;
 
 #[cfg(feature = "rhsm")]

--- a/lib/src/mount.rs
+++ b/lib/src/mount.rs
@@ -21,6 +21,7 @@ use rustix::{
 };
 use serde::Deserialize;
 
+#[cfg(feature = "install-to-disk")]
 use crate::task::Task;
 
 /// Well known identifier for pid 1
@@ -90,6 +91,7 @@ pub(crate) fn inspect_filesystem_by_uuid(uuid: &str) -> Result<Filesystem> {
 
 // Check if a specified device contains an already mounted filesystem
 // in the root mount namespace
+#[cfg(feature = "install-to-disk")]
 pub(crate) fn is_mounted_in_pid1_mountns(path: &str) -> Result<bool> {
     let o = run_findmnt(&["-N"], "1")?;
 
@@ -99,6 +101,7 @@ pub(crate) fn is_mounted_in_pid1_mountns(path: &str) -> Result<bool> {
 }
 
 // Recursively check a given filesystem to see if it contains an already mounted source
+#[cfg(feature = "install-to-disk")]
 pub(crate) fn is_source_mounted(path: &str, mounted_fs: &Filesystem) -> bool {
     if mounted_fs.source.contains(path) {
         return true;
@@ -116,6 +119,7 @@ pub(crate) fn is_source_mounted(path: &str, mounted_fs: &Filesystem) -> bool {
 }
 
 /// Mount a device to the target path.
+#[cfg(feature = "install-to-disk")]
 pub(crate) fn mount(dev: &str, target: &Utf8Path) -> Result<()> {
     Task::new_and_run(
         format!("Mounting {target}"),

--- a/lib/src/podman.rs
+++ b/lib/src/podman.rs
@@ -1,19 +1,14 @@
-#[cfg(feature = "install")]
 use anyhow::Result;
-#[cfg(feature = "install")]
 use camino::Utf8Path;
-#[cfg(feature = "install")]
 use cap_std_ext::cap_std::fs::Dir;
 use serde::Deserialize;
 
 /// Where we look inside our container to find our own image
 /// for use with `bootc install`.
-#[cfg(feature = "install")]
 pub(crate) const CONTAINER_STORAGE: &str = "/var/lib/containers";
 
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
-#[cfg(feature = "install")]
 pub(crate) struct Inspect {
     pub(crate) digest: String,
 }
@@ -27,7 +22,6 @@ pub(crate) struct ImageListEntry {
 }
 
 /// Given an image ID, return its manifest digest
-#[cfg(feature = "install")]
 pub(crate) fn imageid_to_digest(imgid: &str) -> Result<String> {
     use bootc_utils::CommandRunExt;
     let o: Vec<Inspect> = crate::install::run_in_host_mountns("podman")
@@ -41,7 +35,6 @@ pub(crate) fn imageid_to_digest(imgid: &str) -> Result<String> {
 }
 
 /// Return true if there is apparently an active container store at the target path.
-#[cfg(feature = "install")]
 pub(crate) fn storage_exists(root: &Dir, path: impl AsRef<Utf8Path>) -> Result<bool> {
     fn impl_storage_exists(root: &Dir, path: &Utf8Path) -> Result<bool> {
         let lock = "storage.lock";
@@ -55,7 +48,6 @@ pub(crate) fn storage_exists(root: &Dir, path: impl AsRef<Utf8Path>) -> Result<b
 ///
 /// Note this does not attempt to parse the root filesystem's container storage configuration,
 /// this uses a hardcoded default path.
-#[cfg(feature = "install")]
 pub(crate) fn storage_exists_default(root: &Dir) -> Result<bool> {
     storage_exists(root, CONTAINER_STORAGE.trim_start_matches('/'))
 }

--- a/lib/src/status.rs
+++ b/lib/src/status.rs
@@ -102,7 +102,6 @@ pub(crate) struct Deployments {
     pub(crate) other: VecDeque<ostree::Deployment>,
 }
 
-#[cfg(feature = "install")]
 pub(crate) fn try_deserialize_timestamp(t: &str) -> Option<chrono::DateTime<chrono::Utc>> {
     match chrono::DateTime::parse_from_rfc3339(t).context("Parsing timestamp") {
         Ok(t) => Some(t.into()),

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -7,14 +7,10 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use bootc_utils::CommandRunExt;
-#[cfg(feature = "install")]
 use camino::Utf8Path;
 use cap_std_ext::cap_std::fs::Dir;
-#[cfg(feature = "install")]
 use cap_std_ext::dirext::CapStdExtDirExt;
-#[cfg(feature = "install")]
 use cap_std_ext::prelude::CapStdExtCommandExt;
-#[cfg(feature = "install")]
 use fn_error_context::context;
 use indicatif::HumanDuration;
 use libsystemd::logging::journal_print;
@@ -88,7 +84,6 @@ pub fn openat2_with_retry(
 /// Given an mount option string list like foo,bar=baz,something=else,ro parse it and find
 /// the first entry like $optname=
 /// This will not match a bare `optname` without an equals.
-#[cfg(feature = "install")]
 pub(crate) fn find_mount_option<'a>(
     option_string_list: &'a str,
     optname: &'_ str,
@@ -102,7 +97,6 @@ pub(crate) fn find_mount_option<'a>(
 
 /// Given a target directory, if it's a read-only mount, then remount it writable
 #[context("Opening {target} with writable mount")]
-#[cfg(feature = "install")]
 pub(crate) fn open_dir_remount_rw(root: &Dir, target: &Utf8Path) -> Result<Dir> {
     if matches!(root.is_mountpoint(target), Ok(Some(true))) {
         tracing::debug!("Target {target} is a mountpoint, remounting rw");
@@ -118,7 +112,6 @@ pub(crate) fn open_dir_remount_rw(root: &Dir, target: &Utf8Path) -> Result<Dir> 
 
 /// Given a target path, remove its immutability if present
 #[context("Removing immutable flag from {target}")]
-#[cfg(feature = "install")]
 pub(crate) fn remove_immutability(root: &Dir, target: &Utf8Path) -> Result<()> {
     use anyhow::ensure;
 
@@ -175,7 +168,6 @@ pub(crate) fn sigpolicy_from_opts(
 
 /// Output a warning message that we want to be quite visible.
 /// The process (thread) execution will be delayed for a short time.
-#[cfg(feature = "install")]
 pub(crate) fn medium_visibility_warning(s: &str) {
     anstream::eprintln!(
         "{}{s}{}",


### PR DESCRIPTION
I consider `bootc install to-filesystem` support a key feature of bootc. In theory today one can still set up a system directly with `ostree` and we will continue to support that.

But things like logically bound images we do want to be initialized from the start and that's with `bootc install to-filesystem`.

Maintaining the feature just has a logistical annoyance any time one touches the install code as we often end up needing to carefully `#[cfg(feature = "install")]` in many places in an infectious way.

Also as we head towards enabling factory reset
https://github.com/containers/bootc/issues/404
we really do want some of the install code enabled there.

However, `to-disk` is much more of a "demo". I don't want bootc to grow too much knowledge around block devices. Complex setups (LVM, LUKS) etc. are the domain of external installers and provisioning tools.

So the feature gate is now on that (which is still on by default).

We ended up with more `#[cfg(feature = "install-to-disk")]` than I'd have liked, but some of that can be fixed subsequently.