### PR TITLE
install: Add /usr/share/doc/bootc/baseimage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ install:
 	  fi; \
 	  done
 	install -D -m 0644 -t $(DESTDIR)/$(prefix)/lib/systemd/system systemd/*.service systemd/*.timer systemd/*.path systemd/*.target
+	install -D -m 0644 -t $(DESTDIR)/$(prefix)/share/doc/bootc/baseimage/base/usr/lib/ostree/ baseimage/base/usr/lib/ostree/prepare-root.conf
+	install -d -m 755 $(DESTDIR)/$(prefix)/share/doc/bootc/baseimage/base/sysroot
+	cp -PfT baseimage/base/ostree $(DESTDIR)/$(prefix)/share/doc/bootc/baseimage/base/ostree 
 
 # Run this to also take over the functionality of `ostree container` for example.
 # Only needed for OS/distros that have callers invoking `ostree container` and not bootc.

--- a/baseimage/README.md
+++ b/baseimage/README.md
@@ -1,0 +1,10 @@
+# Recommended image content
+
+The subdirectories here are recommended to be installed alongside
+bootc in `/usr/share/doc/bootc/baseimage` - they act as reference
+sources of content.
+
+- [base](base): At the current time the content here is effectively
+  a hard requirement. It's not much, just an ostree configuration
+  enabling composefs, plus the default `sysroot` directory (which
+  may go away in the future) and the `ostree` symlink into `sysroot`.

--- a/baseimage/base/ostree
+++ b/baseimage/base/ostree
@@ -1,0 +1,1 @@
+sysroot/ostree

--- a/baseimage/base/sysroot/.gitignore
+++ b/baseimage/base/sysroot/.gitignore
@@ -1,0 +1,3 @@
+# A trick to keep an empty directory in git
+*
+!.gitignore

--- a/baseimage/base/usr/lib/ostree/prepare-root.conf
+++ b/baseimage/base/usr/lib/ostree/prepare-root.conf
@@ -1,0 +1,2 @@
+[composefs]
+enabled = true

--- a/contrib/packaging/bootc.spec
+++ b/contrib/packaging/bootc.spec
@@ -32,6 +32,7 @@ BuildRequires: libzstd-devel
 %{_prefix}/lib/systemd/system-generators/*
 %{_prefix}/lib/bootc
 %{_unitdir}/*
+%{_docdir}/bootc/*
 %{_mandir}/man*/bootc*
 
 %prep


### PR DESCRIPTION

This directory will contain expected files in the base image.

That said, I may change the container import path to auto-create
at least the sysroot dir and symlink at some point and these
can just be dropped.

And for that matter after
https://github.com/ostreedev/ostree/commit/9a0acd7249bb0c7f55c2bf56e5073902cd60038b
"libostree/deploy: enable composefs by default"
we can likely just drop the prepare-root bit too.

But for now this is needed.

Motivated by improving base image generation from
https://gitlab.com/fedora/bootc/tracker/-/issues/32