### PR TITLE
tree-wide: Move most tests under `mod test`

### DIFF
--- a/lib/src/blockdev.rs
+++ b/lib/src/blockdev.rs
@@ -334,27 +334,27 @@ pub(crate) fn parse_size_mib(mut s: &str) -> Result<u64> {
     Ok(v * mul)
 }
 
-#[test]
-fn test_parse_size_mib() {
-    let ident_cases = [0, 10, 9, 1024].into_iter().map(|k| (k.to_string(), k));
-    let cases = [
-        ("0M", 0),
-        ("10M", 10),
-        ("10MiB", 10),
-        ("1G", 1024),
-        ("9G", 9216),
-        ("11T", 11 * 1024 * 1024),
-    ]
-    .into_iter()
-    .map(|(k, v)| (k.to_string(), v));
-    for (s, v) in ident_cases.chain(cases) {
-        assert_eq!(parse_size_mib(&s).unwrap(), v as u64, "Parsing {s}");
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn test_parse_size_mib() {
+        let ident_cases = [0, 10, 9, 1024].into_iter().map(|k| (k.to_string(), k));
+        let cases = [
+            ("0M", 0),
+            ("10M", 10),
+            ("10MiB", 10),
+            ("1G", 1024),
+            ("9G", 9216),
+            ("11T", 11 * 1024 * 1024),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v));
+        for (s, v) in ident_cases.chain(cases) {
+            assert_eq!(parse_size_mib(&s).unwrap(), v as u64, "Parsing {s}");
+        }
+    }
 
     #[test]
     fn test_parse_sfdisk() -> Result<()> {

--- a/lib/src/glyph.rs
+++ b/lib/src/glyph.rs
@@ -30,7 +30,12 @@ impl Display for Glyph {
     }
 }
 
-#[test]
-fn test_glyph() {
-    assert_eq!(Glyph::BlackCircle.as_utf8(), "●");
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_glyph() {
+        assert_eq!(Glyph::BlackCircle.as_utf8(), "●");
+    }
 }

--- a/lib/src/kernel.rs
+++ b/lib/src/kernel.rs
@@ -37,10 +37,15 @@ pub(crate) fn find_first_cmdline_arg<'a>(
     .next()
 }
 
-#[test]
-fn test_find_first() {
-    let kargs = &["foo=bar", "root=/dev/vda", "blah", "root=/dev/other"];
-    let kargs = || kargs.iter().copied();
-    assert_eq!(find_first_cmdline_arg(kargs(), "root"), Some("/dev/vda"));
-    assert_eq!(find_first_cmdline_arg(kargs(), "nonexistent"), None);
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_first() {
+        let kargs = &["foo=bar", "root=/dev/vda", "blah", "root=/dev/other"];
+        let kargs = || kargs.iter().copied();
+        assert_eq!(find_first_cmdline_arg(kargs(), "root"), Some("/dev/vda"));
+        assert_eq!(find_first_cmdline_arg(kargs(), "nonexistent"), None);
+    }
 }

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -229,47 +229,52 @@ pub(crate) fn digested_pullspec(image: &str, digest: &str) -> String {
     format!("{image}@{digest}")
 }
 
-#[test]
-fn test_digested_pullspec() {
-    let digest = "ebe3bdccc041864e5a485f1e755e242535c3b83d110c0357fe57f110b73b143e";
-    assert_eq!(
-        digested_pullspec("quay.io/example/foo:bar", digest),
-        format!("quay.io/example/foo:bar@{digest}")
-    );
-    assert_eq!(
-        digested_pullspec("quay.io/example/foo@sha256:otherdigest", digest),
-        format!("quay.io/example/foo@{digest}")
-    );
-    assert_eq!(
-        digested_pullspec("quay.io/example/foo", digest),
-        format!("quay.io/example/foo@{digest}")
-    );
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[test]
-fn test_find_mount_option() {
-    const V1: &str = "rw,relatime,compress=foo,subvol=blah,fast";
-    assert_eq!(find_mount_option(V1, "subvol").unwrap(), "blah");
-    assert_eq!(find_mount_option(V1, "rw"), None);
-    assert_eq!(find_mount_option(V1, "somethingelse"), None);
-}
+    #[test]
+    fn test_digested_pullspec() {
+        let digest = "ebe3bdccc041864e5a485f1e755e242535c3b83d110c0357fe57f110b73b143e";
+        assert_eq!(
+            digested_pullspec("quay.io/example/foo:bar", digest),
+            format!("quay.io/example/foo:bar@{digest}")
+        );
+        assert_eq!(
+            digested_pullspec("quay.io/example/foo@sha256:otherdigest", digest),
+            format!("quay.io/example/foo@{digest}")
+        );
+        assert_eq!(
+            digested_pullspec("quay.io/example/foo", digest),
+            format!("quay.io/example/foo@{digest}")
+        );
+    }
 
-#[test]
-fn test_sigpolicy_from_opts() {
-    assert_eq!(
-        sigpolicy_from_opts(false, None),
-        SignatureSource::ContainerPolicy
-    );
-    assert_eq!(
-        sigpolicy_from_opts(true, None),
-        SignatureSource::ContainerPolicyAllowInsecure
-    );
-    assert_eq!(
-        sigpolicy_from_opts(false, Some("foo")),
-        SignatureSource::OstreeRemote("foo".to_owned())
-    );
-    assert_eq!(
-        sigpolicy_from_opts(true, Some("foo")),
-        SignatureSource::ContainerPolicyAllowInsecure
-    );
+    #[test]
+    fn test_find_mount_option() {
+        const V1: &str = "rw,relatime,compress=foo,subvol=blah,fast";
+        assert_eq!(find_mount_option(V1, "subvol").unwrap(), "blah");
+        assert_eq!(find_mount_option(V1, "rw"), None);
+        assert_eq!(find_mount_option(V1, "somethingelse"), None);
+    }
+
+    #[test]
+    fn test_sigpolicy_from_opts() {
+        assert_eq!(
+            sigpolicy_from_opts(false, None),
+            SignatureSource::ContainerPolicy
+        );
+        assert_eq!(
+            sigpolicy_from_opts(true, None),
+            SignatureSource::ContainerPolicyAllowInsecure
+        );
+        assert_eq!(
+            sigpolicy_from_opts(false, Some("foo")),
+            SignatureSource::OstreeRemote("foo".to_owned())
+        );
+        assert_eq!(
+            sigpolicy_from_opts(true, Some("foo")),
+            SignatureSource::ContainerPolicyAllowInsecure
+        );
+    }
 }


### PR DESCRIPTION
This is a general best practice; specifically motivated by handling test-specific imports.