### PR TITLE
install: Add `dracut` subdirectory to baseimage reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ install:
 	install -D -m 0644 -t $(DESTDIR)/$(prefix)/share/doc/bootc/baseimage/base/usr/lib/ostree/ baseimage/base/usr/lib/ostree/prepare-root.conf
 	install -d -m 755 $(DESTDIR)/$(prefix)/share/doc/bootc/baseimage/base/sysroot
 	cp -PfT baseimage/base/ostree $(DESTDIR)/$(prefix)/share/doc/bootc/baseimage/base/ostree 
+	# Ensure we've cleaned out any possibly older files
+	rm -vrf $(DESTDIR)$(prefix)/share/doc/bootc/baseimage/dracut
+	cp -Prf baseimage/dracut $(DESTDIR)$(prefix)/share/doc/bootc/baseimage/dracut
 
 # Run this to also take over the functionality of `ostree container` for example.
 # Only needed for OS/distros that have callers invoking `ostree container` and not bootc.

--- a/baseimage/README.md
+++ b/baseimage/README.md
@@ -8,3 +8,5 @@ sources of content.
   a hard requirement. It's not much, just an ostree configuration
   enabling composefs, plus the default `sysroot` directory (which
   may go away in the future) and the `ostree` symlink into `sysroot`.
+- [dracut](dracut): Default/basic dracut configuration; at the current
+  time this basically just enables ostree in the initramfs.

--- a/baseimage/dracut/usr/lib/dracut.conf.d/10-bootc-base.conf
+++ b/baseimage/dracut/usr/lib/dracut.conf.d/10-bootc-base.conf
@@ -1,0 +1,7 @@
+# Typically we want want a generic image and
+# hostonly makes no sense as part of a server side build.
+# (really hostonly=no should be the default if dracut detects that
+#  it's in a container or so)
+hostonly=no
+# We require ostree in the initramfs
+add_dracutmodules+=" ostree "


### PR DESCRIPTION
ref https://gitlab.com/fedora/bootc/tracker/-/issues/32#note_2270189835

This will keep track of the generic bootc+dracut integration glue here instead of replicating it in different base images.

(Perhaps bootc actually injects code into the initramfs in the
 future instead of ostree, for example)