### PR TITLE
tests: Handle not having skopeo present

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,11 @@ exclude-crate-paths = [ { name = "libz-sys", exclude = "src/zlib" },
                         { name = "k8s-openapi", exclude = "src/v1_27" },
                       ]
 
+# This is an made up key for external binary dependencies.
+# setpriv is a proxy for util-linux, and systemctl is a proxy for systemd.
+[workspace.metadata.binary-dependencies]
+bins = ["skopeo", "podman", "ostree", "zstd", "setpriv", "systemctl"]
+
 [workspace.lints.rust]
 # Require an extra opt-in for unsafe
 unsafe_code = "deny"

--- a/ci/installdeps.sh
+++ b/ci/installdeps.sh
@@ -24,10 +24,11 @@ enabled=1
 enabled_metadata=1
 EOF
 
-# Our tests depend on this
-dnf -y install skopeo zstd
-
+# TODO: Recursively extract this from the existing cargo system-deps metadata
 case $OS_ID in
     fedora) dnf -y builddep bootc ;;
     *) dnf -y install libzstd-devel openssl-devel ostree-devel cargo ;;
 esac
+
+bindeps=$(cargo metadata --format-version 1 --no-deps | jq -r '.metadata.["binary-dependencies"].bins | map("/usr/bin/" + .) | join(" ")')
+dnf -y install $bindeps


### PR DESCRIPTION
Fallout from the ostree-ext merge. We were missing a `BuildRequires`
in the spec, which caused our unit tests to fail in Fedora.
I since added that BuildRequires, but let's change our tests
to skip if it's not present.

Signed-off-by: Colin Walters <walters@verbum.org>