### PR TITLE
Two changes for `bootc-status-updated.path`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ install:
 	  fi; \
 	  done
 	install -D -m 0644 -t $(DESTDIR)/$(prefix)/lib/systemd/system systemd/*.service systemd/*.timer systemd/*.path systemd/*.target
+	install -d -m 0755 $(DESTDIR)/$(prefix)/lib/systemd/system/multi-user.target.wants
+	ln -s ../bootc-status-updated.path $(DESTDIR)/$(prefix)/lib/systemd/system/multi-user.target.wants/bootc-status-updated.path
 	install -D -m 0644 -t $(DESTDIR)/$(prefix)/share/doc/bootc/baseimage/base/usr/lib/ostree/ baseimage/base/usr/lib/ostree/prepare-root.conf
 	install -d -m 755 $(DESTDIR)/$(prefix)/share/doc/bootc/baseimage/base/sysroot
 	cp -PfT baseimage/base/ostree $(DESTDIR)/$(prefix)/share/doc/bootc/baseimage/base/ostree 

--- a/systemd/bootc-status-updated.path
+++ b/systemd/bootc-status-updated.path
@@ -1,6 +1,7 @@
 [Unit]
 Description=Monitor bootc for status changes
 Documentation=man:bootc-status-updated.path(8)
+ConditionPathExists=/run/ostree-booted
 
 [Path]
 PathChanged=/ostree/bootc

--- a/tests/booted/readonly/012-unit-status.nu
+++ b/tests/booted/readonly/012-unit-status.nu
@@ -1,0 +1,18 @@
+# Verify our systemd units are enabled
+use std assert
+use tap.nu
+
+tap begin "verify our systemd units"
+
+let units = [
+    ["unit", "status"]; 
+    # This one should be always enabled by our install logic
+    ["bootc-status-updated.path", "active"]
+]
+
+for elt in $units {
+    let found_status = systemctl show -P ActiveState $elt.unit | str trim
+    assert equal $elt.status $found_status
+}
+
+tap ok


### PR DESCRIPTION
build-sys: Enable `bootc-status-updated.path` by default

Followup to https://github.com/containers/bootc/pull/977

In chatting with John we had some agreement to statically
enable the `.path` unit by default upstream here since
it's a feature we want to be available by default
so that tooling can react dynamically to changes.

Signed-off-by: Colin Walters <walters@verbum.org>

---

bootc-status-updated: Add `ConditionPathExists=/run/ostree-booted`

This is a general best practice for our units to ensure
they don't apply outside of bootc systems.

Signed-off-by: Colin Walters <walters@verbum.org>

---
