### PR TITLE
Rename RHSM file to bootc.facts

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -393,7 +393,7 @@ pub(crate) enum InternalsOpts {
         stateroot: String,
     },
     #[cfg(feature = "rhsm")]
-    /// Publish subscription-manager facts to /etc/rhsm/facts/bootc.json
+    /// Publish subscription-manager facts to /etc/rhsm/facts/bootc.facts
     PublishRhsmFacts,
 }
 

--- a/lib/src/rhsm.rs
+++ b/lib/src/rhsm.rs
@@ -6,7 +6,7 @@ use cap_std_ext::{cap_std, dirext::CapStdExtDirExt};
 use fn_error_context::context;
 use serde::Serialize;
 
-const FACTS_PATH: &str = "etc/rhsm/facts/bootc.json";
+const FACTS_PATH: &str = "etc/rhsm/facts/bootc.facts";
 
 #[derive(Serialize, PartialEq, Eq, Debug, Default)]
 struct RhsmFacts {


### PR DESCRIPTION
The bootc facts file added in https://github.com/containers/bootc/pull/977 uses the wrong file extension to work with subscription-manager.

I've tested this on a bootc system registered to Foreman via subscription-manager:

```
[root@bootc-machine bootc]# subscription-manager facts | grep bootc
bootc.available.digest: Unknown
bootc.available.image: Unknown
bootc.available.version: Unknown
bootc.booted.digest: sha256:48884b0220bb075ce50ae31d8e6739f3e9b3870e746a4b3c87ea2fe3353b7208
bootc.booted.image: quay.io/centos-bootc/centos-bootc:stream10
bootc.booted.version: stream10.20241230.0
bootc.rollback.digest: sha256:e168d2f013ed4cc89771d2c5d1b15951ae09792ed3d647226f48e5b62316d7fb
bootc.rollback.image: quay.io/centos-bootc/centos-bootc:stream10
bootc.rollback.version: stream10.20241216.0
bootc.staged.digest: Unknown
bootc.staged.image: Unknown
bootc.staged.version: Unknown
...
```

Without this change, the facts are not picked up by sub-man.