### PR TITLE
baseimage: Add kernel-install integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,10 @@ install:
 	cp -PfT baseimage/base/ostree $(DESTDIR)/$(prefix)/share/doc/bootc/baseimage/base/ostree 
 	# Ensure we've cleaned out any possibly older files
 	rm -vrf $(DESTDIR)$(prefix)/share/doc/bootc/baseimage/dracut
+	rm -vrf $(DESTDIR)$(prefix)/share/doc/bootc/baseimage/systemd
+	# Copy dracut and systemd config files
 	cp -Prf baseimage/dracut $(DESTDIR)$(prefix)/share/doc/bootc/baseimage/dracut
+	cp -Prf baseimage/systemd $(DESTDIR)$(prefix)/share/doc/bootc/baseimage/systemd
 
 # Run this to also take over the functionality of `ostree container` for example.
 # Only needed for OS/distros that have callers invoking `ostree container` and not bootc.

--- a/baseimage/README.md
+++ b/baseimage/README.md
@@ -10,3 +10,5 @@ sources of content.
   may go away in the future) and the `ostree` symlink into `sysroot`.
 - [dracut](dracut): Default/basic dracut configuration; at the current
   time this basically just enables ostree in the initramfs.
+- [systemd](systemd): Optional configuration for systemd, currently 
+  this has configuration for kernel-install enabling rpm-ostree integration.

--- a/baseimage/systemd/usr/lib/kernel/install.conf
+++ b/baseimage/systemd/usr/lib/kernel/install.conf
@@ -1,0 +1,5 @@
+# kernel-install will not try to run dracut and allow rpm-ostree to
+# take over. Rpm-ostree will use this to know that it is responsible
+# to run dracut and ensure that there is only one kernel in the image
+layout=ostree
+


### PR DESCRIPTION
This is part of the kernel-integration work:
- https://github.com/coreos/rpm-ostree/pull/5135
- https://gitlab.com/fedora/bootc/base-images/-/merge_requests/62
- https://github.com/coreos/rpm-ostree/pull/5209

WIP while we release rpm-ostree.