### PR TITLE
container/lint: Add --rootfs

### DIFF
--- a/docs/src/man/bootc-container-lint.md
+++ b/docs/src/man/bootc-container-lint.md
@@ -5,7 +5,7 @@ checks as part of a container build
 
 # SYNOPSIS
 
-**bootc container lint** \[**-h**\|**\--help**\]
+**bootc container lint** \[**\--rootfs**\] \[**-h**\|**\--help**\]
 
 # DESCRIPTION
 
@@ -16,6 +16,10 @@ This is intended to be invoked via e.g. \`RUN bootc container lint\` as
 part of a build process; it will error if any problems are detected.
 
 # OPTIONS
+
+**\--rootfs**=*ROOTFS* \[default: /\]
+
+:   Operate on the provided rootfs
 
 **-h**, **\--help**
 

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -245,7 +245,11 @@ pub(crate) enum ContainerOpts {
     ///
     /// This is intended to be invoked via e.g. `RUN bootc container lint` as part
     /// of a build process; it will error if any problems are detected.
-    Lint,
+    Lint {
+        /// Operate on the provided rootfs.
+        #[clap(long, default_value = "/")]
+        rootfs: Utf8PathBuf,
+    },
 }
 
 /// Subcommands which operate on images.
@@ -1014,13 +1018,13 @@ async fn run_from_opt(opt: Opt) -> Result<()> {
         Opt::Edit(opts) => edit(opts).await,
         Opt::UsrOverlay => usroverlay().await,
         Opt::Container(opts) => match opts {
-            ContainerOpts::Lint => {
+            ContainerOpts::Lint { rootfs } => {
                 if !ostree_ext::container_utils::is_ostree_container()? {
                     anyhow::bail!(
                         "Not in a ostree container, this command only verifies ostree containers."
                     );
                 }
-
+                let root = &Dir::open_ambient_dir(rootfs, cap_std::ambient_authority())?;
                 lints::lint(root)?;
                 Ok(())
             }


### PR DESCRIPTION
Intended to pair with things like https://github.com/coreos/rpm-ostree/pull/5211 where we operate on a non-booted root.