### PR TITLE
deny: Sync with rpm-ostree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     - uses: EmbarkStudios/cargo-deny-action@v2
       with:
         log-level: warn
-        command: check bans sources licenses
+        command: check -A duplicate bans sources licenses
   install-tests:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'control/skip-ci') }}
     name: "Test install"

--- a/deny.toml
+++ b/deny.toml
@@ -1,5 +1,9 @@
 [licenses]
-allow = ["Apache-2.0", "Apache-2.0 WITH LLVM-exception", "MIT", "BSD-3-Clause", "BSD-2-Clause", "Unicode-DFS-2016"]
+allow = ["Apache-2.0", "Apache-2.0 WITH LLVM-exception", "MIT",
+         "BSD-3-Clause", "BSD-2-Clause", "Zlib",
+         "Unlicense", "CC0-1.0",
+         "Unicode-DFS-2016", "Unicode-3.0"]
+private = { ignore = true }
 
 [[bans.deny]]
 # We want to require FIPS validation downstream, so we use openssl
@@ -8,6 +12,4 @@ name = "ring"
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-allow-git = [
-    "https://github.com/ostreedev/ostree-rs-ext"
-]
+allow-git = []


### PR DESCRIPTION
We should really have a more centrally-maintained `cargo-deny` configuration. I'd argue to maintain it here in bootc to start, but this will be a common thing for other projects in github.com/containers and elsewhere.

Anyways, this needed updating for the new Unicode-3.0 license in some updated unicode crates that I saw in rpm-ostree.

While we're here, quiet the duplicate crate warning in the CI job, as it's just noise. Keep it when running locally so we have some visibility if we care about it.