### PR TITLE
spec: fix build with rhsm

### DIFF
--- a/contrib/packaging/bootc.spec
+++ b/contrib/packaging/bootc.spec
@@ -67,7 +67,7 @@ Provides: ostree-cli(ostree-container)
 %cargo_prep -v vendor
 
 %build
-%if 0%{?rhel} == 10
+%if 0%{?fedora} || 0%{?rhel} >= 10
     %cargo_build %{?with_rhsm:-f rhsm}
 %else
     %cargo_build %{?with_rhsm:--features rhsm}


### PR DESCRIPTION
The Go macros for Fedora, RHEL 10, and ELN (the future RHEL 11) are all in sync; only RHEL 9 and earlier need the old syntax.

Downstream PR: https://src.fedoraproject.org/rpms/bootc/pull-request/7