### PR TITLE
build.sh: Use our embedded spec

### DIFF
--- a/hack/Containerfile
+++ b/hack/Containerfile
@@ -7,6 +7,9 @@
 # https://tmt.readthedocs.io/en/stable/
 ARG base=quay.io/centos-bootc/centos-bootc:stream9
 FROM $base as build
+# Keep this stuff before the `COPY . /build` below to ensure that the packages
+# are cached, i.e. we don't invalidate the package install stage by editing the source.
+COPY contrib /contrib
 COPY hack/build.sh /build.sh
 RUN /build.sh && rm -v /build.sh
 COPY . /build

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -5,10 +5,6 @@ case $ID in
   centos|rhel) dnf config-manager --set-enabled crb;;
   fedora) dnf -y install dnf-utils ;;
 esac
-# Fetch the latest spec from fedora to ensure we've got the latest build deps
-t=$(mktemp --suffix .spec)
-curl -L -o ${t} https://src.fedoraproject.org/rpms/bootc/raw/rawhide/f/bootc.spec
-dnf -y builddep "${t}"
-rm -f "${t}"
+dnf -y builddep ./contrib/packaging/bootc.spec
 # Extra dependencies
 dnf -y install git-core

--- a/tests/containerfiles/lbi/Containerfile
+++ b/tests/containerfiles/lbi/Containerfile
@@ -7,6 +7,9 @@
 # https://tmt.readthedocs.io/en/stable/
 ARG base=quay.io/centos-bootc/centos-bootc:stream9
 FROM $base as build
+# Keep this stuff before the `COPY . /build` below to ensure that the packages
+# are cached, i.e. we don't invalidate the package install stage by editing the source.
+COPY contrib /contrib
 COPY hack/build.sh /build.sh
 RUN /build.sh && rm -v /build.sh
 COPY . /build


### PR DESCRIPTION
One CI run just got a server error fetching the spec from Fedora. We have a spec here (which I don't like but we do) so use it to lower CI flakes.