### PR TITLE
systemd: enable bootc-status-updated.target on startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ install:
 	install -D -m 0644 -t $(DESTDIR)/$(prefix)/lib/systemd/system systemd/*.service systemd/*.timer systemd/*.path systemd/*.target
 	install -d -m 0755 $(DESTDIR)/$(prefix)/lib/systemd/system/multi-user.target.wants
 	ln -s ../bootc-status-updated.path $(DESTDIR)/$(prefix)/lib/systemd/system/multi-user.target.wants/bootc-status-updated.path
+	ln -s ../bootc-status-updated.target $(DESTDIR)/$(prefix)/lib/systemd/system/multi-user.target.wants/bootc-status-updated.target
 	install -D -m 0644 -t $(DESTDIR)/$(prefix)/share/doc/bootc/baseimage/base/usr/lib/ostree/ baseimage/base/usr/lib/ostree/prepare-root.conf
 	install -d -m 755 $(DESTDIR)/$(prefix)/share/doc/bootc/baseimage/base/sysroot
 	cp -PfT baseimage/base/ostree $(DESTDIR)/$(prefix)/share/doc/bootc/baseimage/base/ostree 

--- a/systemd/bootc-status-updated.target
+++ b/systemd/bootc-status-updated.target
@@ -2,3 +2,7 @@
 Description=Target for bootc status changes
 Documentation=man:bootc-status-updated.target(8)
 StopWhenUnneeded=true
+ConditionPathExists=/run/ostree-booted
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Any services that react to status changes should be idempotent, and
should run on boot.  It is likely (but not guaranteed) that during
boot we are in the process of switching from a previous deployment to
a new one, and thus what was previously "staged" is now "booted" and
what was previously "booted" is now "rollback", so anything that cares
about status is going to want to handle that.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>