### PR TITLE
Split off a blockdev internal crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "blockdev"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "bootc-utils",
+ "camino",
+ "fn-error-context",
+ "indoc",
+ "regex",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
 name = "bootc"
 version = "0.1.9"
 dependencies = [
@@ -170,6 +185,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "anyhow",
+ "blockdev",
  "bootc-utils",
  "camino",
  "cap-std-ext",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["cli", "lib", "ostree-ext", "xtask", "tests-integration"]
+members = ["cli", "lib", "ostree-ext", "blockdev", "xtask", "tests-integration"]
 resolver = "2"
 
 [profile.dev]

--- a/blockdev/Cargo.toml
+++ b/blockdev/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+description = "Internal blockdev code"
+# Should never be published to crates.io
+publish = false
+edition = "2021"
+license = "MIT OR Apache-2.0"
+name = "blockdev"
+repository = "https://github.com/containers/bootc"
+version = "0.0.0"
+
+[dependencies]
+anyhow = { workspace = true }
+bootc-utils = { path = "../utils" }
+camino = { workspace = true, features = ["serde1"] }
+fn-error-context = { workspace = true }
+regex = "1.10.4"
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+indoc = "2.0.5"
+
+[lib]
+path = "src/blockdev.rs"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -17,6 +17,7 @@ anstream = "0.6.13"
 anstyle = "1.0.6"
 anyhow = { workspace = true }
 bootc-utils = { path = "../utils" }
+bootc-blockdev = { path = "../blockdev", package = "blockdev" }
 camino = { workspace = true, features = ["serde1"] }
 ostree-ext = { path = "../ostree-ext" }
 chrono = { workspace = true, features = ["serde"] }

--- a/lib/src/bootloader.rs
+++ b/lib/src/bootloader.rs
@@ -2,8 +2,8 @@ use anyhow::{anyhow, bail, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use fn_error_context::context;
 
-use crate::blockdev::PartitionTable;
 use crate::task::Task;
+use bootc_blockdev::PartitionTable;
 
 /// The name of the mountpoint for efi (as a subdirectory of /boot, or at the toplevel)
 pub(crate) const EFI_DIR: &str = "efi";
@@ -69,7 +69,7 @@ pub(crate) fn install_via_zipl(device: &PartitionTable, boot_uuid: &str) -> Resu
     // Ensure that the found partition is a part of the target device
     let device_path = device.path();
 
-    let partitions = crate::blockdev::list_dev(device_path)?
+    let partitions = bootc_blockdev::list_dev(device_path)?
         .children
         .with_context(|| format!("no partition found on {device_path}"))?;
     let boot_part = partitions

--- a/lib/src/install/baseline.rs
+++ b/lib/src/install/baseline.rs
@@ -100,7 +100,7 @@ fn mkfs<'a>(
     wipe: bool,
     opts: impl IntoIterator<Item = &'a str>,
 ) -> Result<uuid::Uuid> {
-    let devinfo = crate::blockdev::list_dev(dev.into())?;
+    let devinfo = bootc_blockdev::list_dev(dev.into())?;
     let size = ostree_ext::glib::format_size(devinfo.size);
     let u = uuid::Uuid::new_v4();
     let mut t = Task::new(
@@ -174,7 +174,7 @@ pub(crate) fn install_create_rootfs(
         .ok_or_else(|| anyhow::anyhow!("No root filesystem specified"))?;
     // Verify that the target is empty (if not already wiped in particular, but it's
     // also good to verify that the wipe worked)
-    let device = crate::blockdev::list_dev(&opts.device)?;
+    let device = bootc_blockdev::list_dev(&opts.device)?;
     // Canonicalize devpath
     let devpath: Utf8PathBuf = device.path().into();
 
@@ -228,7 +228,7 @@ pub(crate) fn install_create_rootfs(
     let root_size = opts
         .root_size
         .as_deref()
-        .map(crate::blockdev::parse_size_mib)
+        .map(bootc_blockdev::parse_size_mib)
         .transpose()
         .context("Parsing root size")?;
 
@@ -317,7 +317,7 @@ pub(crate) fn install_create_rootfs(
     udev_settle()?;
 
     // Re-read what we wrote into structured information
-    let base_partitions = &crate::blockdev::partitions_of(&devpath)?;
+    let base_partitions = &bootc_blockdev::partitions_of(&devpath)?;
 
     let root_partition = base_partitions.find_partno(rootpn)?;
     if root_partition.parttype.as_str() != LINUX_PARTTYPE {
@@ -433,7 +433,7 @@ pub(crate) fn install_create_rootfs(
         BlockSetup::Direct => None,
         BlockSetup::Tpm2Luks => Some(luks_name.to_string()),
     };
-    let device_info = crate::blockdev::partitions_of(&devpath)?;
+    let device_info = bootc_blockdev::partitions_of(&devpath)?;
     Ok(RootSetup {
         luks_device,
         device_info,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -30,7 +30,6 @@ mod utils;
 #[cfg(feature = "docgen")]
 mod docgen;
 
-mod blockdev;
 mod bootloader;
 mod containerenv;
 mod install;


### PR DESCRIPTION
This code has been forked between bootupd and coreos-installer and here. This is prep for having bootupd pull it from bootc's git so we can deduplicate.