### PR TITLE
Add bootc-status-updated-onboot.target 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ install:
 	install -D -m 0644 -t $(DESTDIR)/$(prefix)/lib/systemd/system systemd/*.service systemd/*.timer systemd/*.path systemd/*.target
 	install -d -m 0755 $(DESTDIR)/$(prefix)/lib/systemd/system/multi-user.target.wants
 	ln -s ../bootc-status-updated.path $(DESTDIR)/$(prefix)/lib/systemd/system/multi-user.target.wants/bootc-status-updated.path
-	ln -s ../bootc-status-updated.target $(DESTDIR)/$(prefix)/lib/systemd/system/multi-user.target.wants/bootc-status-updated.target
+	ln -s ../bootc-status-updated-onboot.target $(DESTDIR)/$(prefix)/lib/systemd/system/multi-user.target.wants/bootc-status-updated-onboot.target
 	install -D -m 0644 -t $(DESTDIR)/$(prefix)/share/doc/bootc/baseimage/base/usr/lib/ostree/ baseimage/base/usr/lib/ostree/prepare-root.conf
 	install -d -m 755 $(DESTDIR)/$(prefix)/share/doc/bootc/baseimage/base/sysroot
 	cp -PfT baseimage/base/ostree $(DESTDIR)/$(prefix)/share/doc/bootc/baseimage/base/ostree 

--- a/systemd/bootc-publish-rhsm-facts.service
+++ b/systemd/bootc-publish-rhsm-facts.service
@@ -9,3 +9,4 @@ ExecStart=/usr/bin/bootc internals publish-rhsm-facts
 
 [Install]
 WantedBy=bootc-status-updated.target
+WantedBy=bootc-status-updated-onboot.target

--- a/systemd/bootc-status-updated-onboot.target
+++ b/systemd/bootc-status-updated-onboot.target
@@ -1,5 +1,7 @@
 [Unit]
-Description=Target for bootc status changes
+Description=Target for bootc status changes on boot
 Documentation=man:bootc-status-updated.target(8)
-StopWhenUnneeded=true
 ConditionPathExists=/run/ostree-booted
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The bootc-status-updated.target unit cannot directly be
WantedBy=multi-user.target, because we rely on StopWhenUnneeded=true
so the target will be activated each time bootc-status-updated.path
triggers it.  Because multi-user.target remains active, this would
hold bootc-status-updated.target in an active state as well, and the
path unit activating would not have the desired effect of retriggering
the target unit.

The new bootc-status-updated-onboot.target is intended to serve the
same purpose as bootc-status-updated.target but will activate (and
remain active) on boot.  Any interested units should be WantedBy both
targets.  This updates bootc-publish-rhsm-facts.service to do just
that.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>