### PR TITLE
Switch systemd generator to be a dispatcher shell script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,7 @@ install:
 	install -d -m 0755 $(DESTDIR)$(prefix)/lib/bootc/bound-images.d
 	install -d -m 0755 $(DESTDIR)$(prefix)/lib/bootc/kargs.d
 	ln -s /sysroot/ostree/bootc/storage $(DESTDIR)$(prefix)/lib/bootc/storage
-	install -d -m 0755 $(DESTDIR)$(prefix)/lib/systemd/system-generators/
-	ln -f $(DESTDIR)$(prefix)/bin/bootc $(DESTDIR)$(prefix)/lib/systemd/system-generators/bootc-systemd-generator
+	install -D -m 0755 cli/bootc-generator-stub $(DESTDIR)$(prefix)/lib/systemd/system-generators/bootc-systemd-generator 
 	install -d $(DESTDIR)$(prefix)/lib/bootc/install
 	# Support installing pre-generated man pages shipped in source tarball, to avoid
 	# a dependency on pandoc downstream.  But in local builds these end up in target/man,

--- a/cli/bootc-generator-stub
+++ b/cli/bootc-generator-stub
@@ -1,0 +1,5 @@
+#!/bin/bash
+# We can't actually hardlink because in Fedora (+derivatives)
+# these have different SELinux labels. xref
+# https://issues.redhat.com/browse/RHEL-76188
+exec bootc internals systemd-generator "$@"


### PR DESCRIPTION
rpm can't handle hardlinked binaries with distinct labels today gracefully; ostree (and bootc) always break the hardlink which I think is generally right.

Anyways, switch to a dispatcher shell script to fix this.

To fix https://issues.redhat.com/browse/RHEL-76188