### PR TITLE
build-sys: Two minor patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "blockdev"
+name = "bootc"
+version = "0.1.9"
+dependencies = [
+ "anyhow",
+ "bootc-lib",
+ "clap",
+ "log",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "bootc-blockdev"
 version = "0.0.0"
 dependencies = [
  "anyhow",
@@ -166,26 +179,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "bootc"
-version = "0.1.9"
-dependencies = [
- "anyhow",
- "bootc-lib",
- "clap",
- "log",
- "tokio",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "bootc-lib"
 version = "1.1.4"
 dependencies = [
  "anstream",
  "anstyle",
  "anyhow",
- "blockdev",
+ "bootc-blockdev",
  "bootc-utils",
  "camino",
  "cap-std-ext",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,12 @@
 [workspace]
-members = ["cli", "lib", "ostree-ext", "blockdev", "xtask", "tests-integration"]
+members = [
+    "cli",
+    "lib",
+    "ostree-ext",
+    "blockdev",
+    "xtask",
+    "tests-integration"
+]
 resolver = "2"
 
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "cli",
     "lib",
     "ostree-ext",
+    "utils",
     "blockdev",
     "xtask",
     "tests-integration"

--- a/blockdev/Cargo.toml
+++ b/blockdev/Cargo.toml
@@ -4,7 +4,7 @@ description = "Internal blockdev code"
 publish = false
 edition = "2021"
 license = "MIT OR Apache-2.0"
-name = "blockdev"
+name = "bootc-blockdev"
 repository = "https://github.com/containers/bootc"
 version = "0.0.0"
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -17,7 +17,7 @@ anstream = "0.6.13"
 anstyle = "1.0.6"
 anyhow = { workspace = true }
 bootc-utils = { path = "../utils" }
-bootc-blockdev = { path = "../blockdev", package = "blockdev" }
+bootc-blockdev = { path = "../blockdev" }
 camino = { workspace = true, features = ["serde1"] }
 ostree-ext = { path = "../ostree-ext" }
 chrono = { workspace = true, features = ["serde"] }


### PR DESCRIPTION
build-sys: Split workspace members to multiple lines

To lessen the chance of future conflicts when changing things here.

---

Rename internal blockdev crate to bootc-blockdev

To make a bit clearer this is an internal-to-bootc thing; but also
because other projects like bootupd may start referencing it.

Signed-off-by: Colin Walters <walters@verbum.org>

---