### PR TITLE
lints: Also test main execution

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -1025,7 +1025,7 @@ async fn run_from_opt(opt: Opt) -> Result<()> {
                     );
                 }
                 let root = &Dir::open_ambient_dir(rootfs, cap_std::ambient_authority())?;
-                lints::lint(root, fatal_warnings)?;
+                lints::lint(root, fatal_warnings, std::io::stdout().lock())?;
                 Ok(())
             }
         },


### PR DESCRIPTION
We unit test each lint, but not the main function. As it grows in complexity it'll be useful to unit test.

- Change the function to write to a provided output, not always stdout/stderr
- Add a `passing_fixture` helper that passes all lints
- Fix the baseimage test not to use `??` because that turns the *inner* error into an outer error which is not what we want.