### PR TITLE
ostree-ext: Add bootc feature

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = { workspace = true }
 bootc-utils = { path = "../utils" }
 bootc-blockdev = { path = "../blockdev" }
 camino = { workspace = true, features = ["serde1"] }
-ostree-ext = { path = "../ostree-ext" }
+ostree-ext = { path = "../ostree-ext", features = ["bootc"] }
 chrono = { workspace = true, features = ["serde"] }
 clap = { workspace = true, features = ["derive","cargo"] }
 clap_mangen = { workspace = true, optional = true }

--- a/ostree-ext/Cargo.toml
+++ b/ostree-ext/Cargo.toml
@@ -70,6 +70,8 @@ features = ["dox"]
 docgen = ["clap_mangen"]
 dox = ["ostree/dox"]
 internal-testing-api = ["xshell", "indoc", "similar-asserts"]
+# Enable calling back into bootc
+bootc = []
 
 [lints]
 workspace = true

--- a/ostree-ext/src/container/deploy.rs
+++ b/ostree-ext/src/container/deploy.rs
@@ -143,6 +143,9 @@ pub async fn deploy(
         // crates. We need an option to skip though so when the *main*
         // bootc install code calls this API, we don't do this as it
         // will have already been handled.
+        // Note also we do this under a feature gate to ensure rpm-ostree
+        // doesn't try to invoke this, as that won't work right now.
+        #[cfg(feature = "bootc")]
         if !options.skip_completion {
             // Note that the sysroot is provided as `.`  but we use cwd_dir to
             // make the process current working directory the sysroot.


### PR DESCRIPTION
This is aiming to fix https://github.com/coreos/rpm-ostree/issues/5251 Basically we can't re-invoke the calling process if we aren't actually bootc.

(There are solutions that make this work, but what we'll hopefully
 do shortly is propagate the logic to older streams to have
 bootc take over the handling anyways)