### PR TITLE
misc: Don't use inline const to preserve compat with rust 1.78

### DIFF
--- a/lib/src/mount.rs
+++ b/lib/src/mount.rs
@@ -25,12 +25,13 @@ use serde::Deserialize;
 use crate::task::Task;
 
 /// Well known identifier for pid 1
-pub(crate) const PID1: Pid = const {
+const fn get_pid1() -> Pid {
     match Pid::from_raw(1) {
         Some(v) => v,
         None => panic!("Expected to parse pid1"),
     }
-};
+}
+pub(crate) const PID1: Pid = get_pid1();
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]

--- a/ostree-ext/src/tar/export.rs
+++ b/ostree-ext/src/tar/export.rs
@@ -23,12 +23,13 @@ pub const BARE_SPLIT_XATTRS_MODE: &str = "bare-split-xattrs";
 /// store that version as a constant.
 pub(crate) const SECURITY_SELINUX_XATTR_C: &CStr = c"security.selinux";
 /// Then derive a string version (without the NUL) from the above.
-pub(crate) const SECURITY_SELINUX_XATTR: &str = const {
+const fn get_selinux_xattr() -> &'static str {
     match SECURITY_SELINUX_XATTR_C.to_str() {
         Ok(r) => r,
         Err(_) => unreachable!(),
     }
-};
+}
+pub(crate) const SECURITY_SELINUX_XATTR: &str = get_selinux_xattr();
 
 // This is both special in the tar stream *and* it's in the ostree commit.
 const SYSROOT: &str = "sysroot";


### PR DESCRIPTION
An attempt to fix build failure on: https://github.com/coreos/rpm-ostree/pull/5253