### PR TITLE
Update to ostree-rs 0.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build container (fedora)
-        run: sudo podman build --build-arg=base=quay.io/fedora/fedora-bootc:40 -t localhost/bootc -f hack/Containerfile . 
+        run: sudo podman build --build-arg=base=quay.io/fedora/fedora-bootc:41 -t localhost/bootc -f hack/Containerfile . 
       - name: Container integration
         run: sudo podman run --rm localhost/bootc bootc-integration-tests container
   cargo-deny:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.15.8"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
+checksum = "8d4ba6e40bd1184518716a6e1a781bf9160e286d219ccdb8ab2612e74cfe4789"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -414,7 +414,7 @@ version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -683,7 +683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -883,9 +883,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gio"
-version = "0.18.4"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fc8f532f87b79cbc51a79748f16a6828fb784be93145a322fa14d06d354c73"
+checksum = "a517657589a174be9f60c667f1fec8b7ac82ed5db4ebf56cf073a3b5955d8e2e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -894,30 +894,28 @@ dependencies = [
  "gio-sys",
  "glib",
  "libc",
- "once_cell",
  "pin-project-lite",
  "smallvec",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "gio-sys"
-version = "0.18.1"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
+checksum = "8446d9b475730ebef81802c1738d972db42fde1c5a36a627ebc4d665fc87db04"
 dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
  "system-deps",
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "glib"
-version = "0.18.5"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
+checksum = "f969edf089188d821a30cde713b6f9eb08b20c63fc2e584aba2892a7984a8cc0"
 dependencies = [
  "bitflags 2.6.0",
  "futures-channel",
@@ -931,20 +929,17 @@ dependencies = [
  "gobject-sys",
  "libc",
  "memchr",
- "once_cell",
  "smallvec",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "glib-macros"
-version = "0.18.5"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
+checksum = "715601f8f02e71baef9c1f94a657a9a77c192aea6097cf9ae7e5e177cd8cde68"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro-crate",
- "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -952,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "glib-sys"
-version = "0.18.1"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
+checksum = "b360ff0f90d71de99095f79c526a5888c9c92fc9ee1b19da06c6f5e75f0c2a53"
 dependencies = [
  "libc",
  "system-deps",
@@ -962,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "gobject-sys"
-version = "0.18.0"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
+checksum = "67a56235e971a63bfd75abb13ef70064e1346388723422a68580d8a6fbac6423"
 dependencies = [
  "glib-sys",
  "libc",
@@ -996,12 +991,6 @@ name = "hashbrown"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1453,9 +1442,9 @@ dependencies = [
 
 [[package]]
 name = "ostree"
-version = "0.19.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe85ce8e273f4524322c5d8dabee16b6e4426c67017d03a19e743f92a34ad70"
+checksum = "2c8ae6495e328b0ab2bf0d738f5e7df1151f9ff345cd58198d113f5e1ac4ea36"
 dependencies = [
  "base64",
  "bitflags 1.3.2",
@@ -1517,9 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "ostree-sys"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93abffc3eb7fb90f449e4c476b8b747df1872945803a14c33bbee580ec1ed8c1"
+checksum = "389a71bbeb0adfda235c801c930765d585852f12d63ea30c3411a0547058ef79"
 dependencies = [
  "gio-sys",
  "glib-sys",
@@ -1612,35 +1601,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.20.7",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1840,7 +1805,7 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "once_cell",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2070,7 +2035,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -2107,12 +2072,12 @@ dependencies = [
 
 [[package]]
 name = "system-deps"
-version = "6.2.2"
+version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
+checksum = "66d23aaf9f331227789a99e8de4c91bf46703add012bdfd45fdecdfb2975a005"
 dependencies = [
  "cfg-expr",
- "heck 0.5.0",
+ "heck",
  "pkg-config",
  "toml",
  "version-compare",
@@ -2145,7 +2110,7 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2300,7 +2265,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.22",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2314,17 +2279,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.20.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
@@ -2333,7 +2287,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.20",
+ "winnow",
 ]
 
 [[package]]
@@ -2671,15 +2625,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/hack/Containerfile
+++ b/hack/Containerfile
@@ -1,5 +1,5 @@
 # Build bootc from the current git into a c9s-bootc container image.
-# Use e.g. --build-arg=base=quay.io/fedora/fedora-bootc:40 to target
+# Use e.g. --build-arg=base=quay.io/fedora/fedora-bootc:41 to target
 # Fedora instead.
 #
 # You can also generate an image with cloud-init and other dependencies

--- a/ostree-ext/Cargo.toml
+++ b/ostree-ext/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.15.3"
 # semver here you must also bump our semver.
 containers-image-proxy = "0.7.0"
 # We re-export this library too.
-ostree = { features = ["v2022_6"], version = "0.19.0" }
+ostree = { features = ["v2025_1"], version = "0.20.0" }
 
 # Private dependencies
 anyhow = { workspace = true }

--- a/ostree-ext/src/container/encapsulate.rs
+++ b/ostree-ext/src/container/encapsulate.rs
@@ -68,7 +68,7 @@ fn commit_meta_to_labels<'a>(
     // Copy standard metadata keys `ostree.bootable` and `ostree.linux`.
     // Bootable is an odd one out in being a boolean.
     #[allow(clippy::explicit_auto_deref)]
-    if let Some(v) = meta.lookup::<bool>(*ostree::METADATA_KEY_BOOTABLE)? {
+    if let Some(v) = meta.lookup::<bool>(ostree::METADATA_KEY_BOOTABLE)? {
         labels.insert(ostree::METADATA_KEY_BOOTABLE.to_string(), v.to_string());
         labels.insert(BOOTC_LABEL.into(), "1".into());
     }

--- a/ostree-ext/src/container/store.rs
+++ b/ostree-ext/src/container/store.rs
@@ -602,9 +602,9 @@ impl ImageImporter {
     ) -> Result<Box<PreparedImport>> {
         let config_labels = super::labels_of(&config);
         if self.require_bootable {
-            let bootable_key = *ostree::METADATA_KEY_BOOTABLE;
+            let bootable_key = ostree::METADATA_KEY_BOOTABLE;
             let bootable = config_labels.map_or(false, |l| {
-                l.contains_key(bootable_key) || l.contains_key(BOOTC_LABEL)
+                l.contains_key(bootable_key.as_str()) || l.contains_key(BOOTC_LABEL)
             });
             if !bootable {
                 anyhow::bail!("Target image does not have {bootable_key} label");

--- a/ostree-ext/src/fixture.rs
+++ b/ostree-ext/src/fixture.rs
@@ -414,7 +414,7 @@ fn build_mapping_recurse(
             gio::FileType::Directory => {
                 build_mapping_recurse(path, &child, ret)?;
             }
-            o => anyhow::bail!("Unhandled file type: {}", o),
+            o => anyhow::bail!("Unhandled file type: {o:?}"),
         }
         path.pop();
     }
@@ -725,7 +725,7 @@ impl Fixture {
         metadata.insert("version", &"42.0");
         #[allow(clippy::explicit_auto_deref)]
         if self.bootable {
-            metadata.insert(*ostree::METADATA_KEY_BOOTABLE, &true);
+            metadata.insert(ostree::METADATA_KEY_BOOTABLE, &true);
         }
         let metadata = metadata.to_variant();
         let commit = self.srcrepo.write_commit_with_time(

--- a/ostree-ext/src/ima.rs
+++ b/ostree-ext/src/ima.rs
@@ -8,7 +8,6 @@ use camino::Utf8PathBuf;
 use fn_error_context::context;
 use gio::glib;
 use gio::prelude::*;
-use glib::Cast;
 use glib::Variant;
 use gvariant::aligned_bytes::TryAsAligned;
 use gvariant::{gv, Marker, Structure};

--- a/ostree-ext/src/ostree_prepareroot.rs
+++ b/ostree-ext/src/ostree_prepareroot.rs
@@ -9,8 +9,8 @@ use std::str::FromStr;
 use anyhow::{Context, Result};
 use camino::Utf8Path;
 use cap_std_ext::dirext::CapStdExtDirExt;
-use glib::Cast;
 use ocidir::cap_std::fs::Dir;
+use ostree::glib::object::Cast;
 use ostree::prelude::FileExt;
 use ostree::{gio, glib};
 

--- a/ostree-ext/src/tar/import.rs
+++ b/ostree-ext/src/tar/import.rs
@@ -429,7 +429,7 @@ impl Importer {
                 match &mut self.data {
                     ImporterMode::ObjectSet(_) => {
                         anyhow::bail!(
-                            "Found metadata object {}.{} in object set mode",
+                            "Found metadata object {}.{:?} in object set mode",
                             checksum,
                             objtype
                         );

--- a/tests/containerfiles/lbi/Containerfile
+++ b/tests/containerfiles/lbi/Containerfile
@@ -1,5 +1,5 @@
 # Build bootc from the current git into a c9s-bootc container image.
-# Use e.g. --build-arg=base=quay.io/fedora/fedora-bootc:40 to target
+# Use e.g. --build-arg=base=quay.io/fedora/fedora-bootc:41 to target
 # Fedora instead.
 #
 # You can also generate an image with cloud-init and other dependencies


### PR DESCRIPTION
Notably this drops out several duplicate crates.

Depends on https://github.com/ostreedev/ostree/pull/3378 and (and publishing the update to crates.io)