### PR TITLE
 tar/export: Fix error with zero-sized hardlinked files

### DIFF
--- a/ostree-ext/src/tar/export.rs
+++ b/ostree-ext/src/tar/export.rs
@@ -549,7 +549,8 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
                 let (objpath, h) = self.append_content(checksum)?;
                 let subpath = &dirpath.join(name);
                 let subpath = map_path(subpath);
-                self.append_content_hardlink(&objpath, h, &subpath)?;
+                self.append_content_hardlink(&objpath, h, &subpath)
+                    .with_context(|| format!("Hardlinking {checksum} to {subpath}"))?;
             }
         }
 


### PR DESCRIPTION
tar/export: Add error context

Signed-off-by: Colin Walters <walters@verbum.org>

---

tar/export: Fix error with zero-sized hardlinked files

In the case where we already emitted an object into the tar stream,
we wouldn't previously set the file type and size into the tar
header structure that we passed into the hardlink emission function.
This would cause an error when accessing the (logically) uninitialized `size()`.

Fix the writer function to always set the file type and size unconditionally,
and also rework the consumer side to make the logic even clearer.

Signed-off-by: Colin Walters <walters@verbum.org>

---