### PR TITLE
lint: Drop ostree-container restriction

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -1048,11 +1048,6 @@ async fn run_from_opt(opt: Opt) -> Result<()> {
                 if list {
                     return lints::lint_list(std::io::stdout().lock());
                 }
-                if !ostree_ext::container_utils::is_ostree_container()? {
-                    anyhow::bail!(
-                        "Not in a ostree container, this command only verifies ostree containers."
-                    );
-                }
                 let root = &Dir::open_ambient_dir(rootfs, cap_std::ambient_authority())?;
                 lints::lint(root, fatal_warnings, std::io::stdout().lock())?;
                 Ok(())


### PR DESCRIPTION
We now support deploying containers without `sysroot/ostree`, so drop the requirement for the linter to find that.