### PR TITLE
store: Clean up broken /etc/hostname and /etc/resolv.conf

### DIFF
--- a/tests/booted/readonly/011-hostname.nu
+++ b/tests/booted/readonly/011-hostname.nu
@@ -1,0 +1,11 @@
+use std assert
+use tap.nu
+
+tap begin "verify /etc/hostname is not zero sized"
+
+let hostname = try { ls /etc/hostname | first }
+if $hostname != null {
+    assert not equal $hostname.size 0B
+}
+
+tap ok


### PR DESCRIPTION
We can pretty safely work around this here; zero sized files for both are useless.

Closes: https://github.com/containers/bootc/issues/1064