### PR TITLE
lints: More tests && add --skip

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -257,6 +257,13 @@ pub(crate) enum ContainerOpts {
         /// maintaining this exact format; do not parse it via code or scripts.
         #[clap(long)]
         list: bool,
+
+        /// Skip checking the targeted lints, by name. Use `--list` to discover the set
+        /// of available lints.
+        ///
+        /// Example: --skip nonempty-boot --skip baseimage-root
+        #[clap(long)]
+        skip: Vec<String>,
     },
 }
 
@@ -1044,6 +1051,7 @@ async fn run_from_opt(opt: Opt) -> Result<()> {
                 rootfs,
                 fatal_warnings,
                 list,
+                skip,
             } => {
                 if list {
                     return lints::lint_list(std::io::stdout().lock());
@@ -1060,7 +1068,8 @@ async fn run_from_opt(opt: Opt) -> Result<()> {
                 };
 
                 let root = &Dir::open_ambient_dir(rootfs, cap_std::ambient_authority())?;
-                lints::lint(root, warnings, root_type, std::io::stdout().lock())?;
+                let skip = skip.iter().map(|s| s.as_str());
+                lints::lint(root, warnings, root_type, skip, std::io::stdout().lock())?;
                 Ok(())
             }
         },

--- a/lib/src/lints.rs
+++ b/lib/src/lints.rs
@@ -155,6 +155,7 @@ fn lint_inner(
         if let Some(lint_root_type) = lint.root_type {
             if lint_root_type != root_type {
                 skipped += 1;
+                continue;
             }
         }
 
@@ -546,14 +547,15 @@ mod tests {
         let mut out = Vec::new();
         let root_type = RootType::Running;
         let r = lint_inner(root, root_type, &mut out).unwrap();
-        assert_eq!(r.passed, LINTS.len());
+        let allbut_one = LINTS.len().checked_sub(1).unwrap();
+        assert_eq!(r.passed, allbut_one);
         assert_eq!(r.fatal, 0);
         assert_eq!(r.skipped, 1);
         assert_eq!(r.warnings, 0);
         root.create_dir_all("var/run/foo")?;
         let mut out = Vec::new();
         let r = lint_inner(root, root_type, &mut out).unwrap();
-        assert_eq!(r.passed, LINTS.len().checked_sub(1).unwrap());
+        assert_eq!(r.passed, allbut_one.checked_sub(1).unwrap());
         assert_eq!(r.fatal, 1);
         assert_eq!(r.skipped, 1);
         assert_eq!(r.warnings, 0);


### PR DESCRIPTION
lints; Add unit test checking pass/fail counts

We have a bug here that this will catch.

Signed-off-by: Colin Walters <walters@verbum.org>

---

lints: Actually skip skipped lints

Oops.

Signed-off-by: Colin Walters <walters@verbum.org>

---

lint: Add --skip

This allows people to explicitly skip individual lints; especially
useful for warnings. But maybe people have a legitimate reason
to skip ones we're calling fatal too.

Prep especially for supporting `--fix --skip`.

Signed-off-by: Colin Walters <walters@verbum.org>

---