### PR TITLE
A few misc prep patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std-ext"
-version = "4.0.4"
+version = "4.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5cd561bc80e52c4ed4121c7bae16c585388487243f317817d509e882e8c0512"
+checksum = "6b6312927ec94cf0d277f2aa42ab5fe92b8c1a4c1fa81f119c302bd5b0b46790"
 dependencies = [
  "cap-primitives",
  "cap-tempfile",
@@ -696,7 +696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -921,7 +921,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1838,7 +1838,7 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "once_cell",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2166,7 +2166,7 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/hack/provision-derived.sh
+++ b/hack/provision-derived.sh
@@ -14,4 +14,8 @@ mkdir -p ~/.config/nushell
 echo '$env.config = { show_banner: false, }' > ~/.config/nushell/config.nu
 touch ~/.config/nushell/env.nu
 dnf -y install nu
-dnf clean all && rm /var/log/* -rf
+dnf clean all
+# Stock extra cleaning of logs and caches in general (mostly dnf)
+rm /var/log/* /var/cache /var/lib/dnf /var/lib/rpm-state -rf
+# And clean root's homedir
+rm /var/roothome/.config -rf

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -58,7 +58,7 @@ use crate::progress_jsonl::ProgressWriter;
 use crate::spec::ImageReference;
 use crate::store::Storage;
 use crate::task::Task;
-use crate::utils::{open_dir_noxdev, sigpolicy_from_opt};
+use crate::utils::sigpolicy_from_opt;
 
 /// The toplevel boot directory
 const BOOT: &str = "boot";
@@ -1579,7 +1579,7 @@ fn remove_all_in_dir_no_xdev(d: &Dir, mount_err: bool) -> Result<()> {
         let name = entry.file_name();
         let etype = entry.file_type()?;
         if etype == FileType::dir() {
-            if let Some(subdir) = open_dir_noxdev(d, &name)? {
+            if let Some(subdir) = d.open_dir_noxdev(&name)? {
                 remove_all_in_dir_no_xdev(&subdir, mount_err)?;
                 d.remove_dir(&name)?;
             } else if mount_err {

--- a/lib/src/lints.rs
+++ b/lib/src/lints.rs
@@ -314,7 +314,7 @@ fn check_utf8(dir: &Dir) -> LintResult {
                 return lint_err(format!("/{strname}: Found non-utf8 symlink target"));
             }
         } else if ifmt.is_dir() {
-            let Some(subdir) = crate::utils::open_dir_noxdev(dir, entry.file_name())? else {
+            let Some(subdir) = dir.open_dir_noxdev(entry.file_name())? else {
                 continue;
             };
             if let Err(err) = check_utf8(&subdir)? {

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -13,7 +13,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tracing = { workspace = true }
-tokio = { workspace = true, features = ["process"] }
+tokio = { workspace = true, features = ["process", "rt", "macros"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 
 [dev-dependencies]

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -6,3 +6,97 @@ mod command;
 mod tracing_util;
 pub use command::*;
 pub use tracing_util::*;
+
+/// Given an iterator that's clonable, split it into two iterators
+/// at a given maximum number of elements.
+pub fn iterator_split<I>(
+    it: I,
+    max: usize,
+) -> (impl Iterator<Item = I::Item>, impl Iterator<Item = I::Item>)
+where
+    I: Iterator + Clone,
+{
+    let rest = it.clone();
+    (it.take(max), rest.skip(max))
+}
+
+/// Given an iterator that's clonable, split off the first N elements
+/// at the pivot point. If the iterator would be empty, return None.
+/// Return the count of the remainder.
+pub fn iterator_split_nonempty_rest_count<I>(
+    it: I,
+    max: usize,
+) -> Option<(impl Iterator<Item = I::Item>, usize)>
+where
+    I: Iterator + Clone,
+{
+    let rest = it.clone();
+    let mut it = it.peekable();
+    if it.peek().is_some() {
+        Some((it.take(max), rest.skip(max).count()))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_it_split() {
+        let a: &[&str] = &[];
+        for v in [0, 1, 5] {
+            let (first, rest) = iterator_split(a.iter(), v);
+            assert_eq!(first.count(), 0);
+            assert_eq!(rest.count(), 0);
+        }
+        let a = &["foo"];
+        for v in [1, 5] {
+            let (first, rest) = iterator_split(a.iter(), v);
+            assert_eq!(first.count(), 1);
+            assert_eq!(rest.count(), 0);
+        }
+        let (first, rest) = iterator_split(a.iter(), 1);
+        assert_eq!(first.count(), 1);
+        assert_eq!(rest.count(), 0);
+        let a = &["foo", "bar", "baz", "blah", "other"];
+        let (first, rest) = iterator_split(a.iter(), 2);
+        assert_eq!(first.count(), 2);
+        assert_eq!(rest.count(), 3);
+    }
+
+    #[test]
+    fn test_split_empty_iterator() {
+        let a: &[&str] = &[];
+        for v in [0, 1, 5] {
+            assert!(iterator_split_nonempty_rest_count(a.iter(), v).is_none());
+        }
+    }
+
+    #[test]
+    fn test_split_nonempty_iterator() {
+        let a = &["foo"];
+
+        let Some((elts, 1)) = iterator_split_nonempty_rest_count(a.iter(), 0) else {
+            panic!()
+        };
+        assert_eq!(elts.count(), 0);
+
+        let Some((elts, 0)) = iterator_split_nonempty_rest_count(a.iter(), 1) else {
+            panic!()
+        };
+        assert_eq!(elts.count(), 1);
+
+        let Some((elts, 0)) = iterator_split_nonempty_rest_count(a.iter(), 5) else {
+            panic!()
+        };
+        assert_eq!(elts.count(), 1);
+
+        let a = &["foo", "bar", "baz", "blah", "other"];
+        let Some((elts, 3)) = iterator_split_nonempty_rest_count(a.iter(), 2) else {
+            panic!()
+        };
+        assert_eq!(elts.count(), 2);
+    }
+}


### PR DESCRIPTION
utils: Fix compliation standalone

We use `tokio::test` so need the macros feature.

Signed-off-by: Colin Walters <walters@verbum.org>

---

utils: Add a method to split an iterator

Signed-off-by: Colin Walters <walters@verbum.org>

---

provision-derived: Clean lots more stuff

Yeah, we're going to need a `dnf clean all --everything`...

Signed-off-by: Colin Walters <walters@verbum.org>

---

Update cap-std-ext, use new open_dir_noxdev API

I moved the code there; I plan to use open_dir_noxdev in
the tmpfiles code too which can't depend on lib/util.

Signed-off-by: Colin Walters <walters@verbum.org>

---