### PR TITLE
tests/pushpull: Work around podman/skopeo interaction bug

### DIFF
--- a/tests/booted/test-image-pushpull-upgrade.nu
+++ b/tests/booted/test-image-pushpull-upgrade.nu
@@ -31,6 +31,10 @@ def initial_build [] {
     let td = mktemp -d
     cd $td
 
+    # Work around https://github.com/containers/bootc/pull/1101#issuecomment-2653862974
+    # Basically things break unless "podman" initializes the c/storage instance right now.
+    podman images -q o>/dev/null
+
     bootc image copy-to-storage
     let img = podman image inspect localhost/bootc | from json
 

--- a/tests/booted/test-logically-bound-switch.nu
+++ b/tests/booted/test-logically-bound-switch.nu
@@ -17,6 +17,9 @@ let st = bootc status --json | from json
 let booted = $st.status.booted.image
 
 def initial_setup [] {
+    # Work around https://github.com/containers/bootc/pull/1101#issuecomment-2653862974
+    # Basically things break unless "podman" initializes the c/storage instance right now.
+    podman images -q o>/dev/null
     bootc image copy-to-storage
     podman images
     podman image inspect localhost/bootc | from json


### PR DESCRIPTION
See https://github.com/containers/bootc/pull/1101#issuecomment-2653862974 Basically things break unless "podman" initializes the c/storage instance right now.