### PR TITLE
storage: Ensure global c/storage is initialized via podman

### DIFF
--- a/lib/src/image.rs
+++ b/lib/src/image.rs
@@ -14,6 +14,7 @@ use serde::Serialize;
 use crate::{
     boundimage::query_bound_images,
     cli::{ImageListFormat, ImageListType},
+    imgstorage::ensure_floating_c_storage_initialized,
 };
 
 /// The name of the image we push to containers-storage if nothing is specified.
@@ -138,6 +139,7 @@ pub(crate) async fn push_entrypoint(source: Option<&str>, target: Option<&str>) 
             name: target.to_owned(),
         }
     } else {
+        ensure_floating_c_storage_initialized();
         ImageReference {
             transport: Transport::ContainerStorage,
             name: IMAGE_DEFAULT.to_string(),

--- a/tests/booted/test-image-pushpull-upgrade.nu
+++ b/tests/booted/test-image-pushpull-upgrade.nu
@@ -31,10 +31,6 @@ def initial_build [] {
     let td = mktemp -d
     cd $td
 
-    # Work around https://github.com/containers/bootc/pull/1101#issuecomment-2653862974
-    # Basically things break unless "podman" initializes the c/storage instance right now.
-    podman images -q o>/dev/null
-
     bootc image copy-to-storage
     let img = podman image inspect localhost/bootc | from json
 

--- a/tests/booted/test-logically-bound-switch.nu
+++ b/tests/booted/test-logically-bound-switch.nu
@@ -17,9 +17,6 @@ let st = bootc status --json | from json
 let booted = $st.status.booted.image
 
 def initial_setup [] {
-    # Work around https://github.com/containers/bootc/pull/1101#issuecomment-2653862974
-    # Basically things break unless "podman" initializes the c/storage instance right now.
-    podman images -q o>/dev/null
     bootc image copy-to-storage
     podman images
     podman image inspect localhost/bootc | from json


### PR DESCRIPTION
Two of our tests (and an unknown set of users may) run
`bootc image copy-to-storage` which happens to invoke
skopeo to target /var/lib/containers/storage. If this
happens to be the *first* thing to write to that
c/storage instance it triggers a bug around the podman
image network setup.

Signed-off-by: Colin Walters <walters@verbum.org>