### PR TITLE
reinstall: Clarify that Podman is being installed automatically

### DIFF
--- a/system-reinstall-bootc/src/podman.rs
+++ b/system-reinstall-bootc/src/podman.rs
@@ -80,7 +80,7 @@ pub(crate) fn ensure_podman_installed() -> Result<()> {
     }
 
     tracing::warn!(
-        "Podman was not found on this system. It's required in order to install a bootc image."
+        "Podman was not found on this system. It's required in order to install a bootc image. Attempting to install it automatically."
     );
 
     ensure!(


### PR DESCRIPTION
This warning message is shown when Podman is not found on the system. It
is not clear that the script will attempt to install Podman
automatically if it is not found. This commit changes the message to
make it clear that Podman will be installed automatically.