### PR TITLE
labeler: auto add system-reinstall-bootc label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,3 +16,8 @@ area/install:
   - any-glob-to-any-file:
       - 'lib/src/install.rs'
       - 'lib/src/install/**'
+
+area/system-reinstall-bootc:
+- changed-files:
+  - any-glob-to-any-file:
+      - 'system-reinstall-bootc/**'


### PR DESCRIPTION
Automatically mark any PR touching files in the system-reinstall-bootc
directory with the area/system-reinstall-bootc label.