### PR TITLE
reinstall: Stop waiting for newline after prompt is answered

### DIFF
--- a/system-reinstall-bootc/src/prompt.rs
+++ b/system-reinstall-bootc/src/prompt.rs
@@ -57,7 +57,7 @@ pub(crate) fn ask_yes_no(prompt: &str, default: bool) -> Result<bool> {
     dialoguer::Confirm::new()
         .with_prompt(prompt)
         .default(default)
-        .wait_for_newline(true)
+        .wait_for_newline(false)
         .interact()
         .context("prompting")
 }


### PR DESCRIPTION
When I first used the script, I hit `y` expecting my answer to be accepted. When nothing happened, I hit `y` again and was presented with the same prompt. It took me far too long (I went as far as trying a different shell and terminal) to realize that hitting `y` only toggled the selection to capital `Y`, I had to also hit "enter". This is the first time I've used a script with this behavior. Maybe I'm in the minority but given that this is supposed to be an intuitive tool, should we toggle this flag?