### PR TITLE
kargs: do not set ARCH envvar in tests

### DIFF
--- a/lib/src/kargs.rs
+++ b/lib/src/kargs.rs
@@ -229,7 +229,7 @@ match-architectures = ["x86_64", "aarch64"]
         .to_string();
         let parsed_kargs = parse_kargs_toml(&file_content, sys_arch).unwrap();
         assert_eq!(parsed_kargs, ["console=tty0", "nosmt"]);
-        std::env::set_var("ARCH", "aarch64");
+        let sys_arch = "aarch64";
         let parsed_kargs = parse_kargs_toml(&file_content, sys_arch).unwrap();
         assert_eq!(parsed_kargs, ["console=tty0", "nosmt"]);
     }


### PR DESCRIPTION
std::env::set_var is unsafe in 2024 edition, and upon looking into
that this use in the kargs test came up.  We don't need to set the
environment variable here, in fact I don't think this ever worked in
the first place.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
