### PR TITLE
ostree-ext: store: clear diff_ids when exporting to oci

### DIFF
--- a/ostree-ext/src/container/store.rs
+++ b/ostree-ext/src/container/store.rs
@@ -1414,6 +1414,7 @@ pub(crate) fn export_to_oci(
     new_manifest.layers_mut().clear();
     let mut new_config = srcinfo.configuration.clone();
     new_config.history_mut().clear();
+    new_config.rootfs_mut().diff_ids_mut().clear();
 
     let mut dest_oci = ocidir::OciDir::ensure(dest_oci)?;
 


### PR DESCRIPTION
Resolves: #1134
