### PR TITLE
tracing: Fix RUST_LOG parsing

### DIFF
--- a/utils/src/tracing_util.rs
+++ b/utils/src/tracing_util.rs
@@ -11,9 +11,9 @@ pub fn initialize_tracing() {
         .compact();
     // Log to stderr by default
     tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .event_format(format)
         .with_writer(std::io::stderr)
         .with_max_level(tracing::Level::WARN)
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
 }


### PR DESCRIPTION
This used to work and I'm not exactly sure what changed. For some reason `with_env_filter` needs to be at the end of the chain for the RUST_LOG env var parsing to work.