### PR TITLE
Reinstall ssh crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,6 +1341,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1486,6 +1502,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
+name = "openssh-keys"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb830a82898b2ac17c9620ddce839ac3b34b9cb8a1a037cbdbfb9841c756c3e"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder",
+ "md-5",
+ "sha2",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,7 +1558,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c8ae6495e328b0ab2bf0d738f5e7df1151f9ff345cd58198d113f5e1ac4ea36"
 dependencies = [
- "base64",
+ "base64 0.20.0",
  "bitflags 1.3.2",
  "gio",
  "glib",
@@ -2181,6 +2210,7 @@ dependencies = [
  "clap",
  "dialoguer",
  "log",
+ "openssh-keys",
  "rustix",
  "serde",
  "serde_json",

--- a/system-reinstall-bootc/Cargo.toml
+++ b/system-reinstall-bootc/Cargo.toml
@@ -20,6 +20,7 @@ bootc-utils = { path = "../utils" }
 clap = { workspace = true, features = ["derive"] }
 dialoguer = "0.11.0"
 log = "0.4.21"
+openssh-keys = "0.6.4"
 rustix = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }


### PR DESCRIPTION
This includes the refactor to use the openssh_keys crate and removes the options field from all ssh keys.