### PR TITLE
lib: Add --verbose flag to the CLI for providing a debug option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ bootc.tar.zst
 
 # Added by cargo
 /target
+
+# IDEs / Editors
+.idea/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,7 @@ dependencies = [
  "liboverdrop",
  "libsystemd",
  "linkme",
+ "nix",
  "openssl",
  "ostree-ext",
  "regex",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -54,6 +54,7 @@ uuid = { version = "1.8.0", features = ["v4"] }
 tini = "1.3.0"
 comfy-table = "7.1.1"
 thiserror = { workspace = true }
+nix = "0.27.1"
 
 [dev-dependencies]
 similar-asserts = { workspace = true }

--- a/utils/src/tracing_util.rs
+++ b/utils/src/tracing_util.rs
@@ -1,7 +1,21 @@
 //! Helpers related to tracing, used by main entrypoints
 
+use std::sync::{Arc, OnceLock};
+use tracing::Level;
+use tracing_subscriber::{
+    filter::LevelFilter, fmt, layer::SubscriberExt, reload, EnvFilter, Registry,
+};
+
+/// Global reload handle for dynamically updating log levels
+static TRACING_RELOAD_HANDLE: OnceLock<Arc<reload::Handle<EnvFilter, Registry>>> = OnceLock::new();
+
 /// Initialize tracing with the default configuration.
 pub fn initialize_tracing() {
+    // Create a reloadable EnvFilter: Use `RUST_LOG` if available, otherwise default to WARN
+    let env_filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(LevelFilter::WARN.to_string()));
+    let (filter, reload_handle) = reload::Layer::new(env_filter);
+
     // Don't include timestamps and such because they're not really useful and
     // too verbose, and plus several log targets such as journald will already
     // include timestamps.
@@ -9,11 +23,32 @@ pub fn initialize_tracing() {
         .without_time()
         .with_target(false)
         .compact();
+
+    // Create a subscriber with a reloadable filter and formatted output
     // Log to stderr by default
-    tracing_subscriber::fmt()
-        .event_format(format)
-        .with_writer(std::io::stderr)
-        .with_max_level(tracing::Level::WARN)
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
+    let subscriber = Registry::default().with(filter).with(
+        fmt::layer()
+            .event_format(format)
+            .with_writer(std::io::stderr),
+    );
+
+    // Set the subscriber globally
+    tracing::subscriber::set_global_default(subscriber).expect("Failed to set tracing subscriber");
+
+    // Store the reload handle in a global OnceLock
+    TRACING_RELOAD_HANDLE.set(Arc::new(reload_handle)).ok();
+}
+
+/// Update tracing log level dynamically.
+pub fn update_tracing(log_level: Level) {
+    if let Some(handle) = TRACING_RELOAD_HANDLE.get() {
+        // Create new filter. Use `RUST_LOG` if available
+        let new_filter = EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| EnvFilter::new(log_level.to_string()));
+        if let Err(e) = handle.modify(|filter| *filter = new_filter) {
+            eprintln!("Failed to update log level: {}", e);
+        }
+    } else {
+        eprintln!("Logging system not initialized yet.");
+    }
 }


### PR DESCRIPTION
## Description

This PR adds a `--verbose` flag with the shorts forms `-v`, `-vv`, `-vvv`.. to increase the logging verbosity as requested in #475. 

With this PR, the current command structure looks as follows:

![Screenshot 2025-02-28 at 01 05 34](https://github.com/user-attachments/assets/b911cc8d-5b47-407b-b19c-b3b85130d3dc)

The `verbose` flag is matched to different levels of tracing levels from `WARN` to `TRACE`:

```
// lib/src/cli.rs:1058

// Set log level based on `-v` occurrences
let log_level = match cli.global_args.verbose {
    0 => tracing::Level::WARN,  // Default (no -v)
    1 => tracing::Level::INFO,  // -v
    2 => tracing::Level::DEBUG, // -vv
    _ => tracing::Level::TRACE, // -vvv or more
};
```

So any user can change the tracing level at runtime by adding the flag and changing its count. In the following example, `-vvv` is used for `TRACING` and sub level logs:

![Screenshot 2025-02-23 at 02 51 10](https://github.com/user-attachments/assets/3b3de92b-67b5-4b05-8185-45e503b50875)

Users still can use `RUST_LOG` as they get used to. Usage of `RUST_LOG` overrides the `--verbose` flag if used. So even if you run your command with a `-vv` level, if you set your RUST_LOG as `info`, you will only see the `INFO` and `WARN` logs, not the `DEBUG` ones. This case is provided with a [unit test here](https://github.com/mabulgu/bootc/blob/d7f6a62eade51be189e115de06960fc03ef8b720/lib/src/cli.rs#L1463).

## Test Results

Unit tests (tracing only):

```
running 3 tests
test cli::tracing_tests::test_default_tracing ... ok
test cli::tracing_tests::test_update_tracing_respects_rust_log ... ok
test cli::tracing_tests::test_update_tracing ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 64 filtered out; finished in 0.00s
```

Container tests:

```
➜  bootc git:(issue/475) podman run --rm -ti localhost/bootc bootc-integration-tests container

running 3 tests
test status         ... ok
test install config ... ok
test bootc upgrade  ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.09s
```

Closes: #475
