### PR TITLE
install: Add a generic `install finalize`

### DIFF
--- a/docs/src/bootc-install.md
+++ b/docs/src/bootc-install.md
@@ -161,6 +161,26 @@ storage or filesystem setups, but reuses the "top half" of the logic.
 For example, a goal is to change [Anaconda](https://github.com/rhinstaller/anaconda/)
 to use this.
 
+#### Postprocessing after to-filesystem
+
+Some installation tools may want to inject additional data, such as adding
+an `/etc/hostname` into the target root. At the current time, bootc does
+not offer a direct API to do this. However, the backend for bootc is
+ostree, and it is possible to enumerate the deployments via ostree APIs.
+
+We hope to provide a bootc-supported method to find the deployment in
+the future.
+
+However, for tools that do perform any changes, there is a new
+`bootc install finalize` command which is optional, but recommended
+to run as the penultimate step before unmounting the target filesystem.
+
+This command will perform some basic sanity checks and may also
+perform fixups on the target root. For example, a direction
+currently for bootc is to stop using `/etc/fstab`. While `install finalize`
+does not do this today, in the future it may automatically migrate
+`etc/fstab` to `rootflags` kernel arguments.
+
 ### Using `bootc install to-disk --via-loopback`
 
 Because every `bootc` system comes with an opinionated default installation

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -209,6 +209,12 @@ pub(crate) enum InstallOpts {
     /// will be wiped, but the content of the existing root will otherwise be retained, and will
     /// need to be cleaned up if desired when rebooted into the new root.
     ToExistingRoot(crate::install::InstallToExistingRootOpts),
+    /// Execute this as the penultimate step of an installation using `install to-filesystem`.
+    ///
+    Finalize {
+        /// Path to the mounted root filesystem.
+        root_path: Utf8PathBuf,
+    },
     /// Intended for use in environments that are performing an ostree-based installation, not bootc.
     ///
     /// In this scenario the installation may be missing bootc specific features such as
@@ -1120,6 +1126,9 @@ async fn run_from_opt(opt: Opt) -> Result<()> {
             InstallOpts::EnsureCompletion {} => {
                 let rootfs = &Dir::open_ambient_dir("/", cap_std::ambient_authority())?;
                 crate::install::completion::run_from_anaconda(rootfs).await
+            }
+            InstallOpts::Finalize { root_path } => {
+                crate::install::install_finalize(&root_path).await
             }
         },
         Opt::ExecInHostMountNamespace { args } => {

--- a/tests-integration/src/install.rs
+++ b/tests-integration/src/install.rs
@@ -104,6 +104,13 @@ pub(crate) fn run_alongside(image: &str, mut testargs: libtest_mimic::Arguments)
                 std::fs::write(&tmp_keys, b"ssh-ed25519 ABC0123 testcase@example.com")?;
                 cmd!(sh, "sudo {BASE_ARGS...} {target_args...} -v {tmp_keys}:/test_authorized_keys {image} bootc install to-filesystem {generic_inst_args...} --acknowledge-destructive --karg=foo=bar --replace=alongside --root-ssh-authorized-keys=/test_authorized_keys /target").run()?;
 
+                // Also test install finalize here
+                cmd!(
+                    sh,
+                    "sudo {BASE_ARGS...} {target_args...} {image} bootc install finalize /target"
+                )
+                .run()?;
+
                 generic_post_install_verification()?;
 
                 // Test kargs injected via CLI


### PR DESCRIPTION
Basically I want to get Anaconda to run this, then we can perform arbitrary fixups on whatever it did between the install and reboot without changing Anaconda's code.

Motivated specifically by https://github.com/containers/bootc/issues/971

This also applies to user `%post` scripts for example; maybe those break the bootloader entries in /boot; we have the opportunity to catch such things here.

Or we may choose to start forcibly relabeling the target `/etc`.