### PR TITLE
reinstall: Pull podman image early

### DIFF
--- a/system-reinstall-bootc/src/main.rs
+++ b/system-reinstall-bootc/src/main.rs
@@ -20,6 +20,16 @@ fn run() -> Result<()> {
 
     let config = config::ReinstallConfig::load().context("loading config")?;
 
+    podman::ensure_podman_installed()?;
+
+    //pull image early so it can be inspected, e.g. to check for cloud-init
+    let mut pull_image_command = podman::pull_image_command(&config.bootc_image);
+    pull_image_command
+        .run_with_cmd_context()
+        .context(format!("pulling image {}", &config.bootc_image))?;
+
+    println!();
+
     let ssh_key_file = tempfile::NamedTempFile::new()?;
     let ssh_key_file_path = ssh_key_file
         .path()
@@ -30,17 +40,13 @@ fn run() -> Result<()> {
 
     prompt::get_ssh_keys(ssh_key_file_path)?;
 
-    let mut reinstall_podman_command = podman::command(&config.bootc_image, ssh_key_file_path);
+    let mut reinstall_podman_command =
+        podman::reinstall_command(&config.bootc_image, ssh_key_file_path);
 
     println!();
-
     println!("Going to run command {:?}", reinstall_podman_command);
 
     prompt::temporary_developer_protection_prompt()?;
-
-    // At this poihnt, the user has already given us permission to reinstall their system, so we
-    // feel confident with just installing podman without any further user interaction.
-    podman::ensure_podman_installed()?;
 
     reinstall_podman_command
         .run_with_cmd_context()

--- a/system-reinstall-bootc/src/podman.rs
+++ b/system-reinstall-bootc/src/podman.rs
@@ -4,7 +4,7 @@ use bootc_utils::CommandRunExt;
 use std::process::Command;
 use which::which;
 
-pub(crate) fn command(image: &str, ssh_key_file: &str) -> Command {
+pub(crate) fn reinstall_command(image: &str, ssh_key_file: &str) -> Command {
     let mut podman_command_and_args = [
         // We use podman to run the bootc container. This might change in the future to remove the
         // podman dependency.
@@ -59,6 +59,12 @@ pub(crate) fn command(image: &str, ssh_key_file: &str) -> Command {
     let mut command = Command::new(&all_args[0]);
     command.args(&all_args[1..]);
 
+    command
+}
+
+pub(crate) fn pull_image_command(image: &str) -> Command {
+    let mut command = Command::new("podman");
+    command.args(["pull", image]);
     command
 }
 

--- a/system-reinstall-bootc/src/podman.rs
+++ b/system-reinstall-bootc/src/podman.rs
@@ -1,3 +1,5 @@
+use crate::prompt;
+
 use super::ROOT_KEY_MOUNT_POINT;
 use anyhow::{ensure, Context, Result};
 use bootc_utils::CommandRunExt;
@@ -84,9 +86,7 @@ pub(crate) fn ensure_podman_installed() -> Result<()> {
         return Ok(());
     }
 
-    tracing::warn!(
-        "Podman was not found on this system. It's required in order to install a bootc image. Attempting to install it automatically."
-    );
+    prompt::ask_yes_no("Podman was not found on this system. It's required in order to install a bootc image. Do you want to install it now?", true)?;
 
     ensure!(
         which(podman_install_script_path()).is_ok(),


### PR DESCRIPTION
This splits the `podman pull <image>` and the `podman ... bootc install to-existing` command to prepare for future features (e.g. cloud-init) that will require inspecting the image before constructing the bootc install command.

---

Also adds a prompt before installing podman since it needs to be installed before pulling the image which now happens immediately after running the command, before any other user prompts. Open to other ideas on the UX if this doesn't make sense.