### PR TITLE
store: Really remove empty /etc/resolv.conf and /etc/hostname

### DIFF
--- a/tests/booted/readonly/011-test-resolvconf.nu
+++ b/tests/booted/readonly/011-test-resolvconf.nu
@@ -1,0 +1,23 @@
+use std assert
+use tap.nu
+
+tap begin "verify there's not an empty /etc/resolv.conf in the image"
+
+let st = bootc status --json | from json
+
+let booted_ostree = $st.status.booted.ostree.checksum;
+
+# ostree ls should probably have --json and a clean way to not error on ENOENT
+let resolvconf = ostree ls $booted_ostree /usr/etc | split row (char newline) | find resolv.conf
+if ($resolvconf | length) > 0 {
+    let parts = $resolvconf | first | split row -r '\s+'
+    let ty = $parts | first | split chars | first
+    # If resolv.conf exists in the image, currently require it in our 
+    # test suite to be a symlink (which is hopefully to the systemd/stub-resolv.conf)
+    assert equal $ty 'l'
+    print "resolv.conf is a symlink"
+} else {
+    print "No resolv.conf found in commit"
+}
+
+tap ok


### PR DESCRIPTION
The previous change here was a no-op for two reasons:

- It's actually usr/etc at this point
- We were operating on the wrong rootfs

Fixes: https://github.com/containers/bootc/pull/1096/commits/57bd0dc9835669274696998386a547afb6709ff5